### PR TITLE
Ensure resize operation has the required number of temp images

### DIFF
--- a/libvips/resample/resize.c
+++ b/libvips/resample/resize.c
@@ -77,7 +77,7 @@ vips_resize_build( VipsObject *object )
 	VipsResize *resize = (VipsResize *) object;
 
 	VipsImage **t = (VipsImage **) 
-		vips_object_local_array( object, 6 );
+		vips_object_local_array( object, 7 );
 
 	VipsImage *in;
 	int window_size;


### PR DESCRIPTION
Hi John,

The tilecache created during the resize operation uses the [7th](https://github.com/jcupitt/libvips/blob/master/libvips/resample/resize.c#L160) temporary image but only 6 are allocated.

This fix prevents a memory leak and an occasional segfault.

(PR is for the master branch as I can't find a 7.42 branch for bug fixes.)