### PR TITLE
Improve performance of openslide2vips argb2rgba()

### DIFF
--- a/libvips/foreign/openslide2vips.c
+++ b/libvips/foreign/openslide2vips.c
@@ -46,7 +46,7 @@
  * 9/8/14
  * 	- do argb -> rgba for associated as well 
  * 27/1/15
- * 	- improve unpremultiplication performance for opaque pixels
+ * 	- unpremultiplication speedups for fully opaque/transparent pixels
  */
 
 /*
@@ -417,18 +417,12 @@ argb2rgba( uint32_t *buf, int n, uint32_t bg )
 		VipsPel *out = (VipsPel *) p;
 
 		if( a == 255 ) {
-			out[0] = (x >> 16) & 255;
-			out[1] = (x >> 8) & 255;
-			out[2] = x & 255;
-			out[3] = 255;
+			*p = GUINT32_TO_BE((x << 8) | 255);
 		} 
 		else if( a == 0 ) {
 			/* Use background color.
 			 */
-			out[0] = (bg >> 16) & 255;
-			out[1] = (bg >> 8) & 255;
-			out[2] = bg & 255;
-			out[3] = 255;
+			*p = GUINT32_TO_BE((bg << 8) | 255);
 		}
 		else {
 			/* Undo premultiplication.

--- a/libvips/foreign/openslide2vips.c
+++ b/libvips/foreign/openslide2vips.c
@@ -2,7 +2,7 @@
  *
  * Benjamin Gilbert
  *
- * Copyright (c) 2011-2014 Carnegie Mellon University
+ * Copyright (c) 2011-2015 Carnegie Mellon University
  *
  * 26/11/11
  *	- initial version
@@ -45,6 +45,8 @@
  * 	- add autocrop toggle
  * 9/8/14
  * 	- do argb -> rgba for associated as well 
+ * 27/1/15
+ * 	- improve unpremultiplication performance for opaque pixels
  */
 
 /*
@@ -414,18 +416,26 @@ argb2rgba( uint32_t *buf, int n, uint32_t bg )
 		uint8_t a = x >> 24;
 		VipsPel *out = (VipsPel *) p;
 
-		if( a != 0 ) {
-			out[0] = 255 * ((x >> 16) & 255) / a;
-			out[1] = 255 * ((x >> 8) & 255) / a;
-			out[2] = 255 * (x & 255) / a;
+		if( a == 255 ) {
+			out[0] = (x >> 16) & 255;
+			out[1] = (x >> 8) & 255;
+			out[2] = x & 255;
 			out[3] = 255;
 		} 
-		else {
+		else if( a == 0 ) {
 			/* Use background color.
 			 */
 			out[0] = (bg >> 16) & 255;
 			out[1] = (bg >> 8) & 255;
 			out[2] = bg & 255;
+			out[3] = 255;
+		}
+		else {
+			/* Undo premultiplication.
+			 */
+			out[0] = 255 * ((x >> 16) & 255) / a;
+			out[1] = 255 * ((x >> 8) & 255) / a;
+			out[2] = 255 * (x & 255) / a;
 			out[3] = 255;
 		}
 	}


### PR DESCRIPTION
Almost all pixels emitted by OpenSlide are either fully transparent or fully opaque.  Add a special case for opaque pixels to avoid the multiplication/division, and restructure both special cases to compile to a single shift + OR + bswap.  On my system, this produces a 1.95x speedup in user time for `vips openslideload CMU-1.svs out.v` and a 1.28x speedup for `vips openslideload CMU-1.mrxs --level 2 out.v`.