### PR TITLE
Expose JPEG extension parameters. Support trellis quantisation, deringing and scan optimisation.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -696,6 +696,22 @@ FIND_JPEG(
    with_jpeg=no
   ])
 
+# JPEG extension parameters available in libjpeg-turbo >=1.5.0, mozjpeg >=3.0
+if test x"$with_jpeg" = "xyes"; then
+  AC_MSG_CHECKING([for JPEG extension parameters])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+    #include <stdio.h>
+    #include <jpeglib.h>
+  ]], [[
+    J_BOOLEAN_PARAM test;
+  ]])], [
+    AC_MSG_RESULT([yes])
+    AC_DEFINE([HAVE_JPEG_EXT_PARAMS],1,[libjpeg has extension parameters])
+  ], [
+    AC_MSG_RESULT([no])
+  ])
+fi
+
 # libexif
 AC_ARG_WITH([libexif], 
   AS_HELP_STRING([--without-libexif], [build without libexif (default: test)]))

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -2050,6 +2050,9 @@ vips_jpegload_buffer( void *buf, size_t len, VipsImage **out, ... )
  * @interlace: %gboolean, write an interlaced (progressive) jpeg
  * @strip: %gboolean, remove all metadata from image
  * @no-subsample: %gboolean, disable chroma subsampling
+ * @trellis_quant: %gboolean, apply trellis quantisation to each 8x8 block
+ * @overshoot_deringing: %gboolean, overshoot samples with extreme values
+ * @optimize_scans: %gboolean, split DCT coefficients into separate scans
  *
  * Write a VIPS image to a file as JPEG.
  *
@@ -2087,6 +2090,20 @@ vips_jpegload_buffer( void *buf, size_t len, VipsImage **out, ... )
  * If @no-subsample is set, chrominance subsampling is disabled. This will 
  * improve quality at the cost of larger file size. Useful for high Q factors. 
  *
+ * If @trellis_quant is set and the version of libjpeg supports it
+ * (e.g. mozjpeg >= 3.0), apply trellis quantisation to each 8x8 block.
+ * Reduces file size but increases compression time.
+ *
+ * If @overshoot_deringing is set and the version of libjpeg supports it
+ * (e.g. mozjpeg >= 3.0), apply overshooting to samples with extreme values
+ * for example 0 and 255 for 8-bit. Overshooting may reduce ringing artifacts
+ * from compression, in particular in areas where black text appears on a
+ * white background.
+ *
+ * If @optimize_scans is set and the version of libjpeg supports it
+ * (e.g. mozjpeg >= 3.0), split the spectrum of DCT coefficients into
+ * separate scans. Reduces file size but increases compression time.
+ *
  * See also: vips_jpegsave_buffer(), vips_image_write_to_file().
  *
  * Returns: 0 on success, -1 on error.
@@ -2119,6 +2136,9 @@ vips_jpegsave( VipsImage *in, const char *filename, ... )
  * @interlace: write an interlaced (progressive) jpeg
  * @strip: remove all metadata from image
  * @no-subsample: disable chroma subsampling
+ * @trellis_quant: %gboolean, apply trellis quantisation to each 8x8 block
+ * @overshoot_deringing: %gboolean, overshoot samples with extreme values
+ * @optimize_scans: %gboolean, split DCT coefficients into separate scans
  *
  * As vips_jpegsave(), but save to a memory buffer. 
  *
@@ -2170,6 +2190,9 @@ vips_jpegsave_buffer( VipsImage *in, void **buf, size_t *len, ... )
  * @optimize_coding: compute optimal Huffman coding tables
  * @strip: remove all metadata from image
  * @no-subsample: disable chroma subsampling
+ * @trellis_quant: %gboolean, apply trellis quantisation to each 8x8 block
+ * @overshoot_deringing: %gboolean, overshoot samples with extreme values
+ * @optimize_scans: %gboolean, split DCT coefficients into separate scans
  *
  * As vips_jpegsave(), but save as a mime jpeg on stdout.
  *

--- a/libvips/foreign/jpegsave.c
+++ b/libvips/foreign/jpegsave.c
@@ -91,6 +91,18 @@ typedef struct _VipsForeignSaveJpeg {
 	 */
 	gboolean no_subsample;
 
+	/* Apply trellis quantisation to each 8x8 block.
+	 */
+	gboolean trellis_quant;
+
+	/* Apply overshooting to samples with extreme values e.g. 0 & 255 for 8-bit.
+	 */
+	gboolean overshoot_deringing;
+
+	/* Split the spectrum of DCT coefficients into separate scans.
+	 */
+	gboolean optimize_scans;
+
 } VipsForeignSaveJpeg;
 
 typedef VipsForeignSaveClass VipsForeignSaveJpegClass;
@@ -161,6 +173,27 @@ vips_foreign_save_jpeg_class_init( VipsForeignSaveJpegClass *class )
 		G_STRUCT_OFFSET( VipsForeignSaveJpeg, no_subsample ),
 		FALSE );
 
+	VIPS_ARG_BOOL( class, "trellis_quant", 15,
+		_( "Trellis quantisation" ),
+		_( "Apply trellis quantisation to each 8x8 block" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignSaveJpeg, trellis_quant ),
+		FALSE );
+
+	VIPS_ARG_BOOL( class, "overshoot_deringing", 16,
+		_( "Overshoot de-ringing" ),
+		_( "Apply overshooting to samples with extreme values" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignSaveJpeg, overshoot_deringing ),
+		FALSE );
+
+	VIPS_ARG_BOOL( class, "optimize_scans", 17,
+		_( "Optimize scans" ),
+		_( "Split the spectrum of DCT coefficients into separate scans" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignSaveJpeg, optimize_scans ),
+		FALSE );
+
 }
 
 static void
@@ -196,7 +229,8 @@ vips_foreign_save_jpeg_file_build( VipsObject *object )
 
 	if( vips__jpeg_write_file( save->ready, file->filename,
 		jpeg->Q, jpeg->profile, jpeg->optimize_coding, 
-		jpeg->interlace, save->strip, jpeg->no_subsample ) )
+		jpeg->interlace, save->strip, jpeg->no_subsample,
+		jpeg->trellis_quant, jpeg->overshoot_deringing, jpeg->optimize_scans) )
 		return( -1 );
 
 	return( 0 );
@@ -259,7 +293,8 @@ vips_foreign_save_jpeg_buffer_build( VipsObject *object )
 
 	if( vips__jpeg_write_buffer( save->ready, 
 		&obuf, &olen, jpeg->Q, jpeg->profile, jpeg->optimize_coding, 
-		jpeg->interlace, save->strip, jpeg->no_subsample ) )
+		jpeg->interlace, save->strip, jpeg->no_subsample,
+		jpeg->trellis_quant, jpeg->overshoot_deringing, jpeg->optimize_scans) )
 		return( -1 );
 
 	blob = vips_blob_new( (VipsCallbackFn) vips_free, obuf, olen );
@@ -321,7 +356,8 @@ vips_foreign_save_jpeg_mime_build( VipsObject *object )
 
 	if( vips__jpeg_write_buffer( save->ready, 
 		&obuf, &olen, jpeg->Q, jpeg->profile, jpeg->optimize_coding, 
-		jpeg->interlace, save->strip, jpeg->no_subsample ) )
+		jpeg->interlace, save->strip, jpeg->no_subsample,
+		jpeg->trellis_quant, jpeg->overshoot_deringing, jpeg->optimize_scans) )
 		return( -1 );
 
 	printf( "Content-length: %zd\r\n", olen );

--- a/libvips/foreign/vipsjpeg.h
+++ b/libvips/foreign/vipsjpeg.h
@@ -40,11 +40,13 @@ extern const char *vips__jpeg_suffs[];
 int vips__jpeg_write_file( VipsImage *in, 
 	const char *filename, int Q, const char *profile, 
 	gboolean optimize_coding, gboolean progressive, gboolean strip,
-	gboolean no_subsample );
+	gboolean no_subsample, gboolean trellis_quant,
+	gboolean overshoot_deringing, gboolean optimize_scans );
 int vips__jpeg_write_buffer( VipsImage *in, 
 	void **obuf, size_t *olen, int Q, const char *profile, 
 	gboolean optimize_coding, gboolean progressive, gboolean strip,
-	gboolean no_subsample );
+	gboolean no_subsample, gboolean trellis_quant,
+	gboolean overshoot_deringing, gboolean optimize_scans );
 
 int vips__isjpeg_buffer( void *buf, size_t len );
 int vips__isjpeg( const char *filename );


### PR DESCRIPTION
These features are available now in mozjpeg and support for the extension parameter API will be added to the next release of libjpeg-turbo.

This PR adds `./configure` time detection by looking for the new `J_BOOLEAN_PARAM` enum type of `jpeglib.h`, which will also be present in libjpeg-turbo >= 1.5.

It also uses a runtime guard via the new `jpeg_c_x_param_supported` methods. I believe libjpeg-turbo is hoping to support overshoot deringing first, then add other features later as they are optimised to use intrinsics.

If JPEG extension parameters are not available, which will be for the majority of users right now until libjpeg-turbo updates roll out, the new features that use them silently have no effect. Would you prefer these options to fail if unavailable at runtime?

Here are some examples of the file size reductions one can expect using these new features:

When running the following (existing `optimize_coding` option included here for comparison):
```sh
curl -O https://raw.githubusercontent.com/lovell/sharp/master/test/fixtures/2569067123_aca715a2ee_o.jpg
vipsthumbnail --size=256 --linear --format=tn_%s.jpg 2569067123_aca715a2ee_o.jpg
vipsthumbnail --size=256 --linear --format=tn_oc_%s.jpg[optimize_coding] 2569067123_aca715a2ee_o.jpg
vipsthumbnail --size=256 --linear --format=tn_tq_%s.jpg[trellis_quant] 2569067123_aca715a2ee_o.jpg
vipsthumbnail --size=256 --linear --format=tn_os_%s.jpg[interlace,optimize_scans] 2569067123_aca715a2ee_o.jpg
vipsthumbnail --size=256 --linear --format=tn_ostq_%s.jpg[interlace,optimize_scans,trellis_quant] 2569067123_aca715a2ee_o.jpg
```
With mozjpeg:
```
10103 tn_2569067123_aca715a2ee_o.jpg
 9731 tn_oc_2569067123_aca715a2ee_o.jpg
 8866 tn_tq_2569067123_aca715a2ee_o.jpg
 9608 tn_os_2569067123_aca715a2ee_o.jpg
 8847 tn_ostq_2569067123_aca715a2ee_o.jpg
```
Without mozjpeg:
```
10103 tn_2569067123_aca715a2ee_o.jpg
10103 tn_tq_2569067123_aca715a2ee_o.jpg
 9731 tn_oc_2569067123_aca715a2ee_o.jpg
 9813 tn_os_2569067123_aca715a2ee_o.jpg
 9813 tn_ostq_2569067123_aca715a2ee_o.jpg
```