### PR TITLE
Fix small memory leak in openslide loader

### DIFF
--- a/libvips/foreign/openslide2vips.c
+++ b/libvips/foreign/openslide2vips.c
@@ -380,6 +380,7 @@ readslide_new( const char *filename, VipsImage *out,
 	associated = g_strjoinv( ", ", (char **)
 		openslide_get_associated_image_names( rslide->osr ) );
 	vips_image_set_string( out, "slide-associated-images", associated );
+	VIPS_FREE( associated );
 
 	return( rslide );
 }


### PR DESCRIPTION
Inspired by #261 I ran sharp's leak testing script and, thanks to the forthcoming addition of openslide support, discovered a small leak in openslide2vips which this PR fixes:
```
==2994== 24 bytes in 1 blocks are definitely lost in loss record 2,709 of 6,526
==2994==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==2994==    by 0xCE94610: g_malloc (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0)
==2994==    by 0xCEAD56D: g_strjoinv (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0)
==2994==    by 0xC76B2CB: readslide_new (openslide2vips.c:380)
==2994==    by 0xC76B892: vips__openslide_read (openslide2vips.c:502)
==2994==    by 0xC76BEBB: vips_foreign_load_openslide_load (openslideload.c:131)
```

I also received the following report about dzsave but have yet to track down the source of a leak, if any.
```
==2994== 512 bytes in 2 blocks are definitely lost in loss record 6,199 of 6,526
==2994==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==2994==    by 0xCE94610: g_malloc (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0)
==2994==    by 0xCE7CD42: g_file_read_link (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0)
==2994==    by 0xE39B1B9: gsf_output_stdio_new_valist (in /usr/lib/x86_64-linux-gnu/libgsf-1.so.114.0.27)
==2994==    by 0xE39DBEE: ??? (in /usr/lib/x86_64-linux-gnu/libgsf-1.so.114.0.27)
==2994==    by 0xE39B7E1: gsf_outfile_new_child_full (in /usr/lib/x86_64-linux-gnu/libgsf-1.so.114.0.27)
==2994==    by 0xC758132: vips_gsf_path (dzsave.c:330)
==2994==    by 0xC759C4F: vips_foreign_save_dz_build (dzsave.c:623)
==2994==    by 0xC789F28: vips_object_build (object.c:342)
==2994==    by 0xC794CA7: vips_cache_operation_buildp (cache.c:842)
==2994==    by 0xC799FA8: vips_call_required_optional (operation.c:860)
==2994==    by 0xC79A755: vips_call_by_name (operation.c:900)
==2994==    by 0xC79AB9B: vips_call_split (operation.c:1004)
==2994==    by 0xC75A2C5: vips_dzsave (dzsave.c:2011)
```