### PR TITLE
Ensure expected signature in ExceptionInfo before destroy

### DIFF
--- a/libvips/foreign/magick2vips.c
+++ b/libvips/foreign/magick2vips.c
@@ -143,7 +143,9 @@ read_free( Read *read )
 	VIPS_FREEF( DestroyImage, read->image );
 	VIPS_FREEF( DestroyImageInfo, read->image_info ); 
 	VIPS_FREE( read->frames );
-	DestroyExceptionInfo( &read->exception );
+	if ( (&read->exception)->signature == MagickSignature ) {
+		DestroyExceptionInfo( &read->exception );
+	}
 	VIPS_FREEF( vips_g_mutex_free, read->lock );
 }
 


### PR DESCRIPTION
As `read_free` can be called twice since fc5a4a9, this change is required for GraphicsMagick compatibility. It avoids failing the [assert](http://sourceforge.net/p/graphicsmagick/code/ci/default/tree/magick/error.c#l359) in `DestroyExceptionInfo` on the second occasion.