### PR TITLE
Fix .gir file dependencies

### DIFF
--- a/libvips/Makefile.am
+++ b/libvips/Makefile.am
@@ -91,7 +91,7 @@ introspect_SOURCES = \
 introspection_sources = @vips_introspection_sources@
 
 # we make the vips8 API
-Vips-8.0.gir: libvips.la
+Vips-8.0.gir: introspect
 Vips_8_0_gir_INCLUDES = GObject-2.0
 Vips_8_0_gir_CFLAGS = $(INCLUDES) -I${top_srcdir}/libvips/include
 Vips_8_0_gir_LIBS = libvips.la


### PR DESCRIPTION
Ensure `introspect` is built before `g-ir-scanner` tries to run it.  This should fix MacPorts' Buildbot builds on OS X 10.8 (which run with `make -j8`).