### PR TITLE
Fix memory leak in magick free

### DIFF
--- a/libvips/foreign/magick2vips.c
+++ b/libvips/foreign/magick2vips.c
@@ -140,7 +140,7 @@ read_free( Read *read )
 #endif /*DEBUG*/
 
 	VIPS_FREE( read->filename );
-	VIPS_FREEF( DestroyImage, read->image );
+	VIPS_FREEF( DestroyImageList, read->image );
 	VIPS_FREEF( DestroyImageInfo, read->image_info ); 
 	VIPS_FREE( read->frames );
 	if ( (&read->exception)->signature == MagickSignature ) {


### PR DESCRIPTION
Hey, I was having some issues with converting animated gifs, in that my app was leaking like a sieve, after a couple of days of digging into it, think i finally tracked it down to this diff.

As far as i can tell, calling ```DestroyImage``` only destroys the first image in the list, and leaves the rest around, whereas ```DestroyImageList``` goes through all of them and covers the single image case as well.

The repro for the leak i was trying to fix is fairly simple, just magick_open an animated gif and save it, should be fairly noticeable.