### PR TITLE
fixing typo, should be Ifdef

### DIFF
--- a/libvips/include/vips/vips.h
+++ b/libvips/include/vips/vips.h
@@ -154,7 +154,7 @@ extern "C" {
 
 /* Still in use, but can be turned off.
  */
-#if VIPS_ENABLE_DEPRECATED
+#ifdef VIPS_ENABLE_DEPRECATED
 #include <vips/vips7compat.h>
 #include <vips/dispatch.h>
 #include <vips/almostdeprecated.h>


### PR DESCRIPTION
I think it has to be ifdef–no? Couldn't get it to compile otherwise (XCode 7)