### PR TITLE
Enable compilation of vips8 C++ bindings with MSVC

### DIFF
--- a/cplusplus/VImage.cpp
+++ b/cplusplus/VImage.cpp
@@ -189,7 +189,8 @@ VOption::set( const char *name, std::vector<double> value )
 	pair->input = true;
 
 	g_value_init( &pair->value, VIPS_TYPE_ARRAY_DOUBLE );
-	vips_value_set_array_double( &pair->value, NULL, value.size() ); 
+	vips_value_set_array_double( &pair->value, NULL,
+		static_cast< int >( value.size() ) );
 	array = vips_value_get_array_double( &pair->value, NULL ); 
 
 	for( i = 0; i < value.size(); i++ )  
@@ -212,7 +213,8 @@ VOption::set( const char *name, std::vector<VImage> value )
 	pair->input = true;
 
 	g_value_init( &pair->value, VIPS_TYPE_ARRAY_IMAGE );
-	vips_value_set_array_image( &pair->value, value.size() );
+	vips_value_set_array_image( &pair->value,
+		static_cast< int >( value.size() ) );
 	array = vips_value_get_array_image( &pair->value, NULL );
 
 	for( i = 0; i < value.size(); i++ ) { 
@@ -400,7 +402,7 @@ VOption::get_operation( VipsOperation *operation )
 	std::list<Pair *>::iterator i;
 
 	for( i = options.begin(); i != options.end(); ++i ) 
-		if( not (*i)->input ) {
+		if( ! (*i)->input ) {
 			const char *name = (*i)->name;
 
 			g_object_get_property( G_OBJECT( operation ),

--- a/cplusplus/include/vips/VError8.h
+++ b/cplusplus/include/vips/VError8.h
@@ -39,7 +39,7 @@
 
 VIPS_NAMESPACE_START
 
-class VError : public std::exception {
+class VIPS_CPLUSPLUS_API VError : public std::exception {
 	std::string _what;
 
 public:

--- a/cplusplus/include/vips/VImage8.h
+++ b/cplusplus/include/vips/VImage8.h
@@ -43,11 +43,11 @@ VIPS_NAMESPACE_START
 /* Small utility things.
  */
 
-std::vector<double> to_vectorv( int n, ... ); 
-std::vector<double> to_vector( double value );
-std::vector<double> to_vector( int n, double array[] );
-std::vector<double> negate( std::vector<double> value ); 
-std::vector<double> invert( std::vector<double> value ); 
+VIPS_CPLUSPLUS_API std::vector<double> to_vectorv( int n, ... );
+VIPS_CPLUSPLUS_API std::vector<double> to_vector( double value );
+VIPS_CPLUSPLUS_API std::vector<double> to_vector( int n, double array[] );
+VIPS_CPLUSPLUS_API std::vector<double> negate( std::vector<double> value );
+VIPS_CPLUSPLUS_API std::vector<double> invert( std::vector<double> value );
 
 enum VSteal {
 	NOSTEAL = 0,
@@ -162,9 +162,9 @@ public:
 
 };
 
-class VImage; 
-class VInterpolate; 
-class VOption; 
+class VIPS_CPLUSPLUS_API VImage;
+class VIPS_CPLUSPLUS_API VInterpolate;
+class VIPS_CPLUSPLUS_API VOption;
 
 class VOption
 {

--- a/cplusplus/include/vips/vips8
+++ b/cplusplus/include/vips/vips8
@@ -34,6 +34,19 @@
 
 #include <glib-object.h>
 
+/*
+    Define VIPS_CPLUSPLUS_EXPORTS to build a DLL using MSVC
+*/
+#ifdef _MSC_VER
+#  ifdef VIPS_CPLUSPLUS_EXPORTS
+#    define VIPS_CPLUSPLUS_API __declspec(dllexport)
+#  else
+#    define VIPS_CPLUSPLUS_API __declspec(dllimport)
+#  endif
+#else
+#  define VIPS_CPLUSPLUS_API
+#endif
+
 #define VIPS_NAMESPACE_START namespace vips {
 #define VIPS_NAMESPACE_END }
 


### PR DESCRIPTION
Hi John,

C++ name mangling means the `libvips-cpp-42.dll` file created via mingw can't be used with Node on Windows as MSVC is the only supported compiler on that platform.

This means I need to build the vips8 C++ bindings as a DLL using MSVC, but to do this I had to make a couple of syntactic changes and conditionally add MS-only `__declspec` modifiers to the public API.

Cheers,
Lovell