### PR TITLE
Improve portability of VError class

### DIFF
--- a/cplusplus/include/vips/VError8.h
+++ b/cplusplus/include/vips/VError8.h
@@ -40,15 +40,14 @@
 VIPS_NAMESPACE_START
 
 class VIPS_CPLUSPLUS_API VError : public std::exception {
-	std::string _what;
+	const char *_what;
 
 public:
-	VError( std::string what ) : _what( what ) {}
-	VError() : _what( vips_error_buffer() ) {}
+	VError( std::string what ) { _what = what.c_str(); }
+	VError() { _what = vips_error_buffer(); }
 	virtual ~VError() throw() {}
 
-	// Extract string
-	virtual const char *what() const throw() { return _what.c_str(); }
+	virtual const char *what() const throw() { return _what; }
 	void ostream_print( std::ostream & ) const;
 };
 


### PR DESCRIPTION
Hi John, 

This change to the internals of the VError class switches to a more portable `const char*` C reference from a `std::string` without altering its public API.

The requirement for this stems from MSVC's habit of changing its std library class ABI with every release. For example. a `std::string` allocated in a DLL compiled with MSVC 2013 can't be freed from an executable compiled with MSVC 2014.

This was causing segfaults on Windows within the `~VError()` destructor.

I was able to work around a similar problem on Linux with gcc <= 5.0 vs gcc >= 5.1 by setting the `-D_GLIBCXX_USE_CXX11_ABI=0` flag. Sadly there's no equivalent in MSVC land.

Cheers,
Lovell