### PR TITLE
Use gcc/clang isnan and isinf builtin functions, where available

### DIFF
--- a/libvips/arithmetic/max.c
+++ b/libvips/arithmetic/max.c
@@ -322,7 +322,7 @@ vips_max_stop( VipsStatistic *statistic, void *seq )
 	TYPE m; \
 	\
 	for( i = 0; i < sz && values->n < values->size; i++ ) \
-		if( !isnan( p[i] ) ) \
+		if( !VIPS_ISNAN( p[i] ) ) \
 			vips_values_add( values, p[i], x + i / bands, y ); \
 	m = values->value[0]; \
 	\
@@ -342,7 +342,7 @@ vips_max_stop( VipsStatistic *statistic, void *seq )
 	for( i = 0; i < sz && values->n < values->size; i++ ) { \
 		TYPE mod2 = p[0] * p[0] + p[1] * p[1]; \
 		\
-		if( !isnan( mod2 ) ) \
+		if( !VIPS_ISNAN( mod2 ) ) \
 			vips_values_add( values, p[i], x + i / bands, y ); \
 		\
 		p += 2; \

--- a/libvips/arithmetic/min.c
+++ b/libvips/arithmetic/min.c
@@ -325,7 +325,7 @@ vips_min_stop( VipsStatistic *statistic, void *seq )
 	TYPE m; \
 	\
 	for( i = 0; i < sz && values->n < values->size; i++ ) \
-		if( !isnan( p[i] ) ) \
+		if( !VIPS_ISNAN( p[i] ) ) \
 			vips_values_add( values, p[i], x + i / bands, y ); \
 	m = values->value[0]; \
 	\
@@ -345,7 +345,7 @@ vips_min_stop( VipsStatistic *statistic, void *seq )
 	for( i = 0; i < sz && values->n < values->size; i++ ) { \
 		TYPE mod2 = p[0] * p[0] + p[1] * p[1]; \
 		\
-		if( !isnan( mod2 ) ) \
+		if( !VIPS_ISNAN( mod2 ) ) \
 			vips_values_add( values, p[i], x + i / bands, y ); \
 		\
 		p += 2; \

--- a/libvips/colour/LabQ2sRGB.c
+++ b/libvips/colour/LabQ2sRGB.c
@@ -273,9 +273,9 @@ vips_col_scRGB2sRGB( int range, int *lut,
 	 * Don't use isnormal(), it is false for 0.0 and for subnormal
 	 * numbers. 
 	 */
-	if( isnan( R ) || isinf( R ) ||
-		isnan( G ) || isinf( G ) ||
-		isnan( B ) || isinf( B ) ) { 
+	if( VIPS_ISNAN( R ) || VIPS_ISINF( R ) ||
+		VIPS_ISNAN( G ) || VIPS_ISINF( G ) ||
+		VIPS_ISNAN( B ) || VIPS_ISINF( B ) ) {
 		*r = 0; 
 		*g = 0; 
 		*b = 0; 
@@ -370,9 +370,9 @@ vips_col_scRGB2BW( int range, int *lut, float R, float G, float B,
 	 * Don't use isnormal(), it is false for 0.0 and for subnormal
 	 * numbers. 
 	 */
-	if( isnan( R ) || isinf( R ) ||
-		isnan( G ) || isinf( G ) ||
-		isnan( B ) || isinf( B ) ) { 
+	if( VIPS_ISNAN( R ) || VIPS_ISINF( R ) ||
+		VIPS_ISNAN( G ) || VIPS_ISINF( G ) ||
+		VIPS_ISNAN( B ) || VIPS_ISINF( B ) ) {
 		*g = 0; 
 
 		return( -1 );

--- a/libvips/include/vips/util.h
+++ b/libvips/include/vips/util.h
@@ -40,6 +40,7 @@ extern "C" {
 #endif /*__cplusplus*/
 
 #include <stdio.h>
+#include <math.h>
 
 /* Some platforms don't have M_PI :-(
  */
@@ -156,6 +157,17 @@ G_STMT_START { \
 } G_STMT_END
 
 #define VIPS_CLIP_NONE( V, SEQ ) {}
+
+/* The built-in isnan and isinf functions provided by gcc 4+ and clang are
+ * up to 7x faster than their libc equivalent included from <math.h>.
+ */
+#if defined(__clang__) || (__GNUC__ >= 4)
+#define VIPS_ISNAN( V ) __builtin_isnan( V )
+#define VIPS_ISINF( V ) __builtin_isinf( V )
+#else
+#define VIPS_ISNAN( V ) isnan( V )
+#define VIPS_ISINF( V ) isinf( V )
+#endif
 
 /* Not all platforms have PATH_MAX (eg. Hurd) and we don't need a platform one
  * anyway, just a static buffer big enough for almost any path.


### PR DESCRIPTION
Hi John,

Profiling `vipsthumbnail` using `callgrind` reveals there are a lot of `isnan` and `isinf` checks during the building of colour translation look-up tables at start-up time. GCC and clang don't/can't optimise these and will instead call the libc implementation.

In my tests, switching to the builtin versions improves `vipsthumbnail` perf by ~4% with -O2 and by ~9% with -O3 (I guess the builtins become non-compliant with IEEE754 when optimised).

I read (somewhere, can't find it now) that the builtin functions are up to 7x faster than libc on ARM CPUs.

Results, with timing and instruction counts, for running the command follow:

$ vipsthumbnail [2569067123_aca715a2ee_o.jpg](https://github.com/lovell/sharp/blob/master/test/fixtures/2569067123_aca715a2ee_o.jpg)

Cheers,
Lovell


**Before, with -O2**
```
real    0m0.146s
user    0m0.128s
sys     0m0.020s

44,446,001  ???:decode_mcu [/usr/local/lib/libjpeg.so.8.1.2]
37,981,208  /libvips/colour/LabQ2sRGB.c:vips_col_scRGB2sRGB [/usr/local/lib/libvips.so.42.3.1]
16,379,136  /libvips/colour/Lab2XYZ.c:vips_Lab2XYZ_line [/usr/local/lib/libvips.so.42.3.1]
10,810,291  /libvips/colour/LabQ2sRGB.c:build_tables [/usr/local/lib/libvips.so.42.3.1]
 9,437,184  /build/buildd/eglibc-2.19/math/../sysdeps/ieee754/flt-32/s_isinff.c:isinff [/lib/x86_64-linux-gnu/libc-2.19.so]
 9,175,040  /libvips/colour/LabQ2sRGB.c:vips_col_XYZ2scRGB [/usr/local/lib/libvips.so.42.3.1]
 8,410,131  /build/buildd/eglibc-2.19/elf/dl-lookup.c:do_lookup_x [/lib/x86_64-linux-gnu/ld-2.19.so]
 7,351,186  ???:decompress_onepass [/usr/local/lib/libjpeg.so.8.1.2]
 7,340,032  /libvips/colour/Lab2XYZ.c:vips_col_Lab2XYZ [/usr/local/lib/libvips.so.42.3.1]
 5,462,293  /build/buildd/eglibc-2.19/stdio-common/vfprintf.c:vfprintf [/lib/x86_64-linux-gnu/libc-2.19.so]
 5,266,800  ???:jsimd_idct_2x2 [/usr/local/lib/libjpeg.so.8.1.2]
 4,718,603  /libvips/colour/LabQ2sRGB.c:vips_col_scRGB2sRGB_8 [/usr/local/lib/libvips.so.42.3.1]
 4,718,592  /build/buildd/eglibc-2.19/math/../sysdeps/ieee754/flt-32/s_isnanf.c:isnanf [/lib/x86_64-linux-gnu/libc-2.19.so]
```

**Before with -O3**
```
real    0m0.139s
user    0m0.117s
sys     0m0.024s

44,446,001  ???:decode_mcu [/usr/local/lib/libjpeg.so.8.1.2]
36,828,229  ???:vips_col_scRGB2sRGB_8 [/usr/local/lib/libvips.so.42.3.1]
10,810,228  ???:build_tables [/usr/local/lib/libvips.so.42.3.1]
 9,476,352  ???:vips_col_Lab2XYZ [/usr/local/lib/libvips.so.42.3.1]
 9,437,184  /build/buildd/eglibc-2.19/math/../sysdeps/ieee754/flt-32/s_isinff.c:isinff [/lib/x86_64-linux-gnu/libc-2.19.so]
 9,175,040  ???:vips_col_XYZ2scRGB [/usr/local/lib/libvips.so.42.3.1]
 8,409,903  /build/buildd/eglibc-2.19/elf/dl-lookup.c:do_lookup_x [/lib/x86_64-linux-gnu/ld-2.19.so]
 7,351,186  ???:decompress_onepass [/usr/local/lib/libjpeg.so.8.1.2]
 5,462,293  /build/buildd/eglibc-2.19/stdio-common/vfprintf.c:vfprintf [/lib/x86_64-linux-gnu/libc-2.19.so]
 5,266,800  ???:jsimd_idct_2x2 [/usr/local/lib/libjpeg.so.8.1.2]
 4,718,592  /build/buildd/eglibc-2.19/math/../sysdeps/ieee754/flt-32/s_isnanf.c:isnanf [/lib/x86_64-linux-gnu/libc-2.19.so]
```

**After with -O2**
```
real    0m0.140s
user    0m0.132s
sys     0m0.008s

44,446,001  ???:decode_mcu [/usr/local/lib/libjpeg.so.8.1.2]
29,711,837  /libvips/colour/LabQ2sRGB.c:vips_col_scRGB2sRGB [/usr/local/lib/libvips.so.42.3.1]
16,379,136  /libvips/colour/Lab2XYZ.c:vips_Lab2XYZ_line [/usr/local/lib/libvips.so.42.3.1]
10,810,291  /libvips/colour/LabQ2sRGB.c:build_tables [/usr/local/lib/libvips.so.42.3.1]
 9,175,040  /libvips/colour/LabQ2sRGB.c:vips_col_XYZ2scRGB [/usr/local/lib/libvips.so.42.3.1]
 8,409,115  /build/buildd/eglibc-2.19/elf/dl-lookup.c:do_lookup_x [/lib/x86_64-linux-gnu/ld-2.19.so]
 7,351,186  ???:decompress_onepass [/usr/local/lib/libjpeg.so.8.1.2]
 7,340,032  /libvips/colour/Lab2XYZ.c:vips_col_Lab2XYZ [/usr/local/lib/libvips.so.42.3.1]
 5,462,293  /build/buildd/eglibc-2.19/stdio-common/vfprintf.c:vfprintf [/lib/x86_64-linux-gnu/libc-2.19.so]
 5,266,800  ???:jsimd_idct_2x2 [/usr/local/lib/libjpeg.so.8.1.2]
 4,718,603  /libvips/colour/LabQ2sRGB.c:vips_col_scRGB2sRGB_8 [/usr/local/lib/libvips.so.42.3.1]
 ```

**After with -O3**
```
real    0m0.128s
user    0m0.108s
sys     0m0.024s

44,446,001  ???:decode_mcu [/usr/local/lib/libjpeg.so.8.1.2]
33,158,212  ???:vips_col_scRGB2sRGB_8 [/usr/local/lib/libvips.so.42.3.1]
10,810,228  ???:build_tables [/usr/local/lib/libvips.so.42.3.1]
 9,476,352  ???:vips_col_Lab2XYZ [/usr/local/lib/libvips.so.42.3.1]
 9,175,040  ???:vips_col_XYZ2scRGB [/usr/local/lib/libvips.so.42.3.1]
 8,408,887  /build/buildd/eglibc-2.19/elf/dl-lookup.c:do_lookup_x [/lib/x86_64-linux-gnu/ld-2.19.so]
 7,351,186  ???:decompress_onepass [/usr/local/lib/libjpeg.so.8.1.2]
 5,462,293  /build/buildd/eglibc-2.19/stdio-common/vfprintf.c:vfprintf [/lib/x86_64-linux-gnu/libc-2.19.so]
 5,266,800  ???:jsimd_idct_2x2 [/usr/local/lib/libjpeg.so.8.1.2]
```