### PR TITLE
Allow compiler to use vector unit with vips_shrinkh for ~25% boost

### DIFF
--- a/libvips/resample/shrinkh.c
+++ b/libvips/resample/shrinkh.c
@@ -111,18 +111,15 @@ vips_shrinkh_start( VipsImage *out, void *a, void *b )
 	TYPE * restrict q = (TYPE *) out; \
 	\
 	for( x = 0; x < width; x++ ) { \
-		for( b = 0; b < bands; b++ ) \
+		for( b = 0; b < bands; b++ ) { \
 			sum[b] = 0; \
-		\
-		for( b = 0; b < bands; b++ ) \
 			for( x1 = b; x1 < ne; x1 += bands ) \
 				sum[b] += p[x1]; \
-		p += ne; \
-		\
-		for( b = 0; b < bands; b++ ) \
 			q[b] = (sum[b] + shrink->xshrink / 2) / \
 				shrink->xshrink; \
-		q += b; \
+		} \
+		p += ne; \
+		q += bands; \
 	} \
 }
 
@@ -134,17 +131,14 @@ vips_shrinkh_start( VipsImage *out, void *a, void *b )
 	TYPE * restrict q = (TYPE *) out; \
 	\
 	for( x = 0; x < width; x++ ) { \
-		for( b = 0; b < bands; b++ ) \
+		for( b = 0; b < bands; b++ ) { \
 			sum[b] = 0.0; \
-		\
-		for( b = 0; b < bands; b++ ) \
 			for( x1 = b; x1 < ne; x1 += bands ) \
 				sum[b] += p[x1]; \
-		p += ne; \
-		\
-		for( b = 0; b < bands; b++ ) \
 			q[b] = sum[b] / shrink->xshrink; \
-		q += b; \
+		} \
+		p += ne; \
+		q += bands; \
 	} \
 } 
 
@@ -227,7 +221,7 @@ vips_shrinkh_gen( VipsRegion *or, void *vseq,
 
 		s.left = r->left * shrink->xshrink;
 		s.top = r->top + y;
-		s.width = ceil( r->width * shrink->xshrink );
+		s.width = r->width * shrink->xshrink;
 		s.height = 1;
 #ifdef DEBUG
 		printf( "shrinkh_gen: requesting line %d\n", s.top ); 


### PR DESCRIPTION
Hi John,

Based on `callgrind` testing, these changes seem to grant the compiler (gcc 5.3 in my tests) use of the vector unit with `vips_shrinkh`.

When compiled with -O3 this allows `vips_shrinkh_gen` to run with ~25% fewer instructions, so the `vips_shrink` operation as a whole runs up to about 10% faster.

I'm seeing the performance of a more typical shrink+affine reduction improved by ~5%.

Below are the `callgrind` results of running a 2x shrink operation on a WebP image 100x.

Current code, using -O2, `vips_shrinkh_gen` and `vips_shrinkv_gen` are about the same.
```
6,191,513,100  ???:0x000000000002ca10 [/usr/lib/x86_64-linux-gnu/libwebp.so.5.0.1]
5,729,485,600  ???:0x000000000000d140 [/usr/lib/x86_64-linux-gnu/libwebp.so.5.0.1]
2,634,604,404  resample/shrinkh.c:vips_shrinkh_gen [/usr/local/lib/libvips.so.42.3.1]
2,619,589,004  resample/shrinkv.c:vips_shrinkv_gen [/usr/local/lib/libvips.so.42.3.1]
2,150,232,000  ???:0x0000000000021380 [/usr/lib/x86_64-linux-gnu/libwebp.so.5.0.1]
```
Current code, using -O3, `vips_shrinkv_gen` uses half the instructions of `vips_shrinkh_gen`.
```
6,191,513,100  ???:0x000000000002ca10 [/usr/lib/x86_64-linux-gnu/libwebp.so.5.0.1]
5,729,485,600  ???:0x000000000000d140 [/usr/lib/x86_64-linux-gnu/libwebp.so.5.0.1]
2,911,713,804  ???:vips_shrinkh_gen [/usr/local/lib/libvips.so.42.3.1]
2,150,232,000  ???:0x0000000000021380 [/usr/lib/x86_64-linux-gnu/libwebp.so.5.0.1]
2,091,408,000  ???:0x00000000000211e0 [/usr/lib/x86_64-linux-gnu/libwebp.so.5.0.1]
1,806,064,000  ???:0x0000000000020c60 [/usr/lib/x86_64-linux-gnu/libwebp.so.5.0.1]
1,772,999,400  ???:0x0000000000037f10 [/usr/lib/x86_64-linux-gnu/libwebp.so.5.0.1]
1,723,104,000  ???:VP8YuvToRgb32 [/usr/lib/x86_64-linux-gnu/libwebp.so.5.0.1]
1,554,228,000  ???:0x00000000000216f0 [/usr/lib/x86_64-linux-gnu/libwebp.so.5.0.1]
1,489,110,804  ???:vips_shrinkv_gen [/usr/local/lib/libvips.so.42.3.1]
1,405,190,245  ???:0x0000000000033600 [/usr/lib/x86_64-linux-gnu/libwebp.so.5.0.1]
```
With this patch, using -O3, `vips_shrinkh_gen` uses ~25% fewer instructions.
```
6,191,513,100  ???:0x000000000002ca10 [/usr/lib/x86_64-linux-gnu/libwebp.so.5.0.1]
5,729,485,600  ???:0x000000000000d140 [/usr/lib/x86_64-linux-gnu/libwebp.so.5.0.1]
2,150,232,000  ???:0x0000000000021380 [/usr/lib/x86_64-linux-gnu/libwebp.so.5.0.1]
2,140,833,200  ???:vips_shrinkh_gen [/usr/local/lib/libvips.so.42.3.1]
2,091,408,000  ???:0x00000000000211e0 [/usr/lib/x86_64-linux-gnu/libwebp.so.5.0.1]
1,806,064,000  ???:0x0000000000020c60 [/usr/lib/x86_64-linux-gnu/libwebp.so.5.0.1]
1,772,999,400  ???:0x0000000000037f10 [/usr/lib/x86_64-linux-gnu/libwebp.so.5.0.1]
1,723,104,000  ???:VP8YuvToRgb32 [/usr/lib/x86_64-linux-gnu/libwebp.so.5.0.1]
1,554,228,000  ???:0x00000000000216f0 [/usr/lib/x86_64-linux-gnu/libwebp.so.5.0.1]
1,489,110,804  ???:vips_shrinkv_gen [/usr/local/lib/libvips.so.42.3.1]
1,405,190,245  ???:0x0000000000033600 [/usr/lib/x86_64-linux-gnu/libwebp.so.5.0.1]
```
Cheers,
Lovell