### PR TITLE
Small perf improvements to vips_affine + bicubic

### DIFF
--- a/libvips/resample/affine.c
+++ b/libvips/resample/affine.c
@@ -155,29 +155,6 @@ typedef VipsResampleClass VipsAffineClass;
 
 G_DEFINE_TYPE( VipsAffine, vips_affine, VIPS_TYPE_RESAMPLE );
 
-/*
- * FAST_PSEUDO_FLOOR is a floor and floorf replacement which has been
- * found to be faster on several linux boxes than the library
- * version. It returns the floor of its argument unless the argument
- * is a negative integer, in which case it returns one less than the
- * floor. For example:
- *
- * FAST_PSEUDO_FLOOR(0.5) = 0
- *
- * FAST_PSEUDO_FLOOR(0.) = 0
- *
- * FAST_PSEUDO_FLOOR(-.5) = -1
- *
- * as expected, but
- *
- * FAST_PSEUDO_FLOOR(-1.) = -2
- *
- * The locations of the discontinuities of FAST_PSEUDO_FLOOR are the
- * same as floor and floorf; it is just that at negative integers the
- * function is discontinuous on the right instead of the left.
- */
-#define FAST_PSEUDO_FLOOR(x) ( (int)(x) - ( (x) < 0. ) )
-
 /* We have five (!!) coordinate systems. Working forward through them, these
  * are:
  *
@@ -374,8 +351,7 @@ vips_affine_gen( VipsRegion *or, void *seq, void *a, void *b, gboolean *stop )
 					(int) iy - window_offset + 
 						window_size - 1 ) );
 
-				interpolate( affine->interpolate, 
-					q, ir, ix, iy );
+				interpolate( NULL, q, ir, ix, iy );
 			}
 			else {
 				for( z = 0; z < ps; z++ ) 

--- a/libvips/resample/bicubic.cpp
+++ b/libvips/resample/bicubic.cpp
@@ -153,19 +153,17 @@ bicubic_unsigned_int_tab( void *pout, const VipsPel *pin,
 		const T qua_thr = in[l3_plus_b2];
 		const T qua_fou = in[l3_plus_b3];
 
-		int bicubic = bicubic_unsigned_int<T>(
+		out[z] = bicubic_unsigned_int<T>(
 			uno_one, uno_two, uno_thr, uno_fou,
 			dos_one, dos_two, dos_thr, dos_fou,
 			tre_one, tre_two, tre_thr, tre_fou,
 			qua_one, qua_two, qua_thr, qua_fou,
 			cx, cy );
 
-		if( bicubic < 0 )
-			bicubic = 0;
-		else if( bicubic > max_value )
-			bicubic = max_value;
-
-		out[z] = bicubic;
+		if( out[z] < 0 )
+			out[z] = 0;
+		else if( out[z] > max_value )
+			out[z] = max_value;
 
 		in += 1;
 	}
@@ -219,19 +217,17 @@ bicubic_signed_int_tab( void *pout, const VipsPel *pin,
 		const T qua_thr = in[l3_plus_b2];
 		const T qua_fou = in[l3_plus_b3];
 
-		int bicubic = bicubic_signed_int<T>(
+		out[z] = bicubic_signed_int<T>(
 			uno_one, uno_two, uno_thr, uno_fou,
 			dos_one, dos_two, dos_thr, dos_fou,
 			tre_one, tre_two, tre_thr, tre_fou,
 			qua_one, qua_two, qua_thr, qua_fou,
 			cx, cy );
 
-		if( bicubic < min_value )
-			bicubic = min_value;
-		else if( bicubic > max_value )
-			bicubic = max_value;
-
-		out[z] = bicubic;
+		if( out[z] < min_value )
+			out[z] = min_value;
+		else if( out[z] > max_value )
+			out[z] = max_value;
 
 		in += 1;
 	}

--- a/libvips/resample/mapim.c
+++ b/libvips/resample/mapim.c
@@ -70,29 +70,6 @@ typedef VipsResampleClass VipsMapimClass;
 
 G_DEFINE_TYPE( VipsMapim, vips_mapim, VIPS_TYPE_RESAMPLE );
 
-/*
- * FAST_PSEUDO_FLOOR is a floor and floorf replacement which has been
- * found to be faster on several linux boxes than the library
- * version. It returns the floor of its argument unless the argument
- * is a negative integer, in which case it returns one less than the
- * floor. For example:
- *
- * FAST_PSEUDO_FLOOR(0.5) = 0
- *
- * FAST_PSEUDO_FLOOR(0.) = 0
- *
- * FAST_PSEUDO_FLOOR(-.5) = -1
- *
- * as expected, but
- *
- * FAST_PSEUDO_FLOOR(-1.) = -2
- *
- * The locations of the discontinuities of FAST_PSEUDO_FLOOR are the
- * same as floor and floorf; it is just that at negative integers the
- * function is discontinuous on the right instead of the left.
- */
-#define FAST_PSEUDO_FLOOR(x) ( (int)(x) - ( (x) < 0. ) )
-
 #define MINMAX( TYPE ) { \
 	TYPE * restrict p1 = (TYPE *) p; \
 	\

--- a/libvips/resample/presample.h
+++ b/libvips/resample/presample.h
@@ -50,6 +50,35 @@ extern "C" {
 	(G_TYPE_INSTANCE_GET_CLASS( (obj), \
 		VIPS_TYPE_RESAMPLE, VipsResampleClass ))
 
+/*
+ * __builtin_floor is the fastest available floor function, if available.
+ *
+ * FAST_PSEUDO_FLOOR is a floor and floorf replacement which has been
+ * found to be faster on several linux boxes than the library
+ * version. It returns the floor of its argument unless the argument
+ * is a negative integer, in which case it returns one less than the
+ * floor. For example:
+ *
+ * FAST_PSEUDO_FLOOR(0.5) = 0
+ *
+ * FAST_PSEUDO_FLOOR(0.) = 0
+ *
+ * FAST_PSEUDO_FLOOR(-.5) = -1
+ *
+ * as expected, but
+ *
+ * FAST_PSEUDO_FLOOR(-1.) = -2
+ *
+ * The locations of the discontinuities of FAST_PSEUDO_FLOOR are the
+ * same as floor and floorf; it is just that at negative integers the
+ * function is discontinuous on the right instead of the left.
+ */
+#if defined(__clang__) || (__GNUC__ >= 4)
+#define FAST_PSEUDO_FLOOR(x) __builtin_floor( x )
+#else
+#define FAST_PSEUDO_FLOOR(x) ( (int)(x) - ( (x) < 0. ) )
+#endif
+
 typedef struct _VipsResample {
 	VipsOperation parent_instance;
 

--- a/libvips/resample/templates.h
+++ b/libvips/resample/templates.h
@@ -29,29 +29,6 @@
  */
 
 /*
- * FAST_PSEUDO_FLOOR is a floor and floorf replacement which has been
- * found to be faster on several linux boxes than the library
- * version. It returns the floor of its argument unless the argument
- * is a negative integer, in which case it returns one less than the
- * floor. For example:
- *
- * FAST_PSEUDO_FLOOR(0.5) = 0
- *
- * FAST_PSEUDO_FLOOR(0.) = 0
- *
- * FAST_PSEUDO_FLOOR(-.5) = -1
- *
- * as expected, but
- *
- * FAST_PSEUDO_FLOOR(-1.) = -2
- *
- * The locations of the discontinuities of FAST_PSEUDO_FLOOR are the
- * same as floor and floorf; it is just that at negative integers the
- * function is discontinuous on the right instead of the left.
- */
-#define FAST_PSEUDO_FLOOR(x) ( (int)(x) - ( (x) < 0. ) )
-
-/*
  * Various casts which assume that the data is already in range. (That
  * is, they are to be used with monotone samplers.)
  */


### PR DESCRIPTION
Hi John,

There were a few copies of the `FAST_PSEUDO_FLOOR` macro, so these all now reference the same version and, if available, will use the ~7% faster `__builtin_floor` function.

`vips_afffine_gen` already uses `vips_interpolate_get_method` so the `interpolate` instance isn't required by the `interpolate` method. I've run the sharp unit tests over this to ensure all the interpolators still work.

It looks like register starvation was starting to affect `vips_interpolate_bicubic_interpolate` so there's now one less temp variable in there.

The result is ~10% less time spent in `vips_affine_gen` and ~5% less time spent in `vips_interpolate_bicubic_interpolate`.

I see an overall improvement to `vips_affine` of ~3%.

Cheers,
Lovell


Before:

```
4,444,599,308  ???:decode_mcu [/usr/local/lib/libjpeg.so.8.1.2]
1,532,000,000  ???:vips_interpolate_bicubic_interpolate(_VipsInterpolate*, void*, _VipsRegion*, double, double) [/usr/local/lib/libvips.so.42.3.1]
1,141,811,867  ???:conv_gen'2 [/usr/local/lib/libvips.so.42.3.1]
1,133,844,404  ???:conv_gen [/usr/local/lib/libvips.so.42.3.1]
  735,118,204  ???:decompress_onepass [/usr/local/lib/libjpeg.so.8.1.2]
  526,680,000  ???:jsimd_idct_2x2 [/usr/local/lib/libjpeg.so.8.1.2]
  289,870,000  ???:jpeg_fill_bit_buffer [/usr/local/lib/libjpeg.so.8.1.2]
  245,142,470  /build/buildd/eglibc-2.19/string/../sysdeps/x86_64/memset.S:memset [/lib/x86_64-linux-gnu/libc-2.19.so]
  155,446,012  ???:vips_affine_gen [/usr/local/lib/libvips.so.42.3.1]
  139,199,712  ???:g_hash_table_lookup [/lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0]
```
After:
```
4,444,599,308  ???:decode_mcu [/usr/local/lib/libjpeg.so.8.1.2]
1,460,000,000  ???:vips_interpolate_bicubic_interpolate(_VipsInterpolate*, void*, _VipsRegion*, double, double) [/usr/local/lib/libvips.so.42.3.1]
1,141,811,631  ???:conv_gen'2 [/usr/local/lib/libvips.so.42.3.1]
1,133,844,404  ???:conv_gen [/usr/local/lib/libvips.so.42.3.1]
  735,118,204  ???:decompress_onepass [/usr/local/lib/libjpeg.so.8.1.2]
  526,680,000  ???:jsimd_idct_2x2 [/usr/local/lib/libjpeg.so.8.1.2]
  289,870,000  ???:jpeg_fill_bit_buffer [/usr/local/lib/libjpeg.so.8.1.2]
  245,125,190  /build/buildd/eglibc-2.19/string/../sysdeps/x86_64/memset.S:memset [/lib/x86_64-linux-gnu/libc-2.19.so]
  139,206,416  ???:vips_affine_gen [/usr/local/lib/libvips.so.42.3.1]
  139,196,155  ???:g_hash_table_lookup [/lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0]
```