### PR TITLE
Performance: only build LAB to sRGB look-up tables if needed

### DIFF
--- a/libvips/colour/LabQ2sRGB.c
+++ b/libvips/colour/LabQ2sRGB.c
@@ -468,6 +468,8 @@ vips_col_make_tables_LabQ2sRGB( void )
 static void
 vips_LabQ2sRGB_line( VipsColour *colour, VipsPel *q, VipsPel **in, int width )
 { 
+	vips_col_make_tables_LabQ2sRGB();
+
 	unsigned char *p = (unsigned char *) in[0];
 
         int i, t;
@@ -526,8 +528,6 @@ vips_LabQ2sRGB_class_init( VipsLabQ2sRGBClass *class )
 	object_class->description = _( "convert a LabQ image to sRGB" );
 
 	colour_class->process_line = vips_LabQ2sRGB_line;
-
-	vips_col_make_tables_LabQ2sRGB();
 }
 
 static void


### PR DESCRIPTION
This change makes `vips_LabQ2sRGB_line` follow the pattern of the pixel-based conversion functions such as `vips_col_scRGB2sRGB_8` by only building the LUTs when first used.

More importantly, this change reduces the start-up time of the `vips`, `vipsthumbnail` etc. command line tools by ~20ms. For trivial operations on small images, where a LAB to sRGB conversion is not used, I see a ~3x speed-up.