### PR TITLE
Ensure premultiply fast-path for RGBA is used

### DIFF
--- a/libvips/conversion/premultiply.c
+++ b/libvips/conversion/premultiply.c
@@ -87,7 +87,7 @@ G_DEFINE_TYPE( VipsPremultiply, vips_premultiply, VIPS_TYPE_CONVERSION );
 
 /* Special case for RGBA, it's very common.
  */
-#define PRE_RGB( IN, OUT ) { \
+#define PRE_RGBA( IN, OUT ) { \
 	IN * restrict p = (IN *) in; \
 	OUT * restrict q = (OUT *) out; \
 	\
@@ -107,8 +107,8 @@ G_DEFINE_TYPE( VipsPremultiply, vips_premultiply, VIPS_TYPE_CONVERSION );
 }
 
 #define PRE( IN, OUT ) { \
-	if( bands == 3 ) { \
-		PRE_RGB( IN, OUT ); \
+	if( bands == 4 ) { \
+		PRE_RGBA( IN, OUT ); \
 	} \
 	else { \
 		PRE_MANY( IN, OUT ); \


### PR DESCRIPTION
This also updates the macro name to make it more descriptive and consistent with its equivalent in `vips_unpremultiply`.

This makes `vips_premultiply` ~10% faster plus prevents a segfault in the (very uncommon) case of 2 bands plus alpha channel.

Example instruction count before:
```
204,704,256  ???:vips_premultiply_gen [/usr/local/lib/libvips.so.42.4.0]
176,529,416  ???:vips_cast_gen [/usr/local/lib/libvips.so.42.4.0]
```
and after:
```
176,529,416  ???:vips_cast_gen [/usr/local/lib/libvips.so.42.4.0]
119,760,384  ???:vips_premultiply_gen [/usr/local/lib/libvips.so.42.4.0]
```