### PR TITLE
Fix required poppler-glib version in AC_MSG_WARN()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -555,7 +555,7 @@ if test x"$with_poppler" != x"no"; then
      with_poppler=yes
      PACKAGES_USED="$PACKAGES_USED poppler-glib cairo"
     ],
-    [AC_MSG_WARN([poppler-glib >= 0.40.0 or cairo >= 1.2 not found; disabling PDF load via poppler])
+    [AC_MSG_WARN([poppler-glib >= 0.30.0 or cairo >= 1.2 not found; disabling PDF load via poppler])
      with_poppler=no
     ]
   )


### PR DESCRIPTION
The pkg-config test requires >= 0.30.0, but the warning message asks for >= 0.40.0.