### PR TITLE
Use WebP Advanced Encoding API and make it tunable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -677,7 +677,7 @@ AC_ARG_WITH([libwebp],
   AS_HELP_STRING([--without-libwebp], [build without libwebp (default: test)]))
 
 if test x"$with_libwebp" != "xno"; then
-  PKG_CHECK_MODULES(LIBWEBP, libwebp,
+  PKG_CHECK_MODULES(LIBWEBP, libwebp >= 0.1.3,
     [AC_DEFINE(HAVE_LIBWEBP,1,[define if you have libwebp installed.])
      with_libwebp=yes
      PACKAGES_USED="$PACKAGES_USED libwebp"],
@@ -972,6 +972,7 @@ SVG import with librsvg-2.0: 		$with_rsvg
   (requires librsvg-2.0 2.40.0 or later)
 file import with cfitsio: 		$with_cfitsio
 file import/export with libwebp:	$with_libwebp
+  (requires libwebp-0.1.3 or later)
 text rendering with pangoft2: 		$with_pangoft2
 file import/export with libpng: 	$with_png
   (requires libpng-1.2.9 or later)

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -2458,6 +2458,8 @@ vips_webpload_buffer( void *buf, size_t len, VipsImage **out, ... )
  * Optional arguments:
  *
  * @Q: quality factor
+ * @lossless: enables lossless compression
+ * @preset: #VipsForeignWebpPreset choose lossy compression preset
  *
  * See also: vips_webpload(), vips_image_write_to_file().
  *
@@ -2486,6 +2488,8 @@ vips_webpsave( VipsImage *in, const char *filename, ... )
  * Optional arguments:
  *
  * @Q: JPEG quality factor
+ * @lossless: enables lossless compression
+ * @preset: #VipsForeignWebpPreset choose lossy compression preset
  *
  * See also: vips_webpsave().
  *

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -2497,6 +2497,12 @@ vips_webpsave( VipsImage *in, const char *filename, ... )
  * @near_lossless: use preprocessing in lossless mode (controlled by Q)
  * @alpha_q: set alpha quality in lossless mode
  *
+ * As vips_webpsave(), but save to a memory buffer.
+ *
+ * The address of the buffer is returned in @obuf, the length of the buffer in
+ * @olen. You are responsible for freeing the buffer with g_free() when you
+ * are done with it. The buffer is freed for you on error.
+ *
  * See also: vips_webpsave().
  *
  * Returns: 0 on success, -1 on error.

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -2460,6 +2460,7 @@ vips_webpload_buffer( void *buf, size_t len, VipsImage **out, ... )
  * @Q: quality factor
  * @lossless: enables lossless compression
  * @preset: #VipsForeignWebpPreset choose lossy compression preset
+ * @smart_subsample: enables high quality chroma subsampling
  *
  * See also: vips_webpload(), vips_image_write_to_file().
  *
@@ -2490,6 +2491,7 @@ vips_webpsave( VipsImage *in, const char *filename, ... )
  * @Q: JPEG quality factor
  * @lossless: enables lossless compression
  * @preset: #VipsForeignWebpPreset choose lossy compression preset
+ * @smart_subsample: enables high quality chroma subsampling
  *
  * See also: vips_webpsave().
  *

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -2462,6 +2462,7 @@ vips_webpload_buffer( void *buf, size_t len, VipsImage **out, ... )
  * @preset: #VipsForeignWebpPreset choose lossy compression preset
  * @smart_subsample: enables high quality chroma subsampling
  * @near_lossless: use preprocessing in lossless mode (controlled by Q)
+ * @alpha_q: set alpha quality in lossless mode
  *
  * See also: vips_webpload(), vips_image_write_to_file().
  *
@@ -2494,6 +2495,7 @@ vips_webpsave( VipsImage *in, const char *filename, ... )
  * @preset: #VipsForeignWebpPreset choose lossy compression preset
  * @smart_subsample: enables high quality chroma subsampling
  * @near_lossless: use preprocessing in lossless mode (controlled by Q)
+ * @alpha_q: set alpha quality in lossless mode
  *
  * See also: vips_webpsave().
  *

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -2461,6 +2461,7 @@ vips_webpload_buffer( void *buf, size_t len, VipsImage **out, ... )
  * @lossless: enables lossless compression
  * @preset: #VipsForeignWebpPreset choose lossy compression preset
  * @smart_subsample: enables high quality chroma subsampling
+ * @near_lossless: use preprocessing in lossless mode (controlled by Q)
  *
  * See also: vips_webpload(), vips_image_write_to_file().
  *
@@ -2492,6 +2493,7 @@ vips_webpsave( VipsImage *in, const char *filename, ... )
  * @lossless: enables lossless compression
  * @preset: #VipsForeignWebpPreset choose lossy compression preset
  * @smart_subsample: enables high quality chroma subsampling
+ * @near_lossless: use preprocessing in lossless mode (controlled by Q)
  *
  * See also: vips_webpsave().
  *

--- a/libvips/foreign/vips2webp.c
+++ b/libvips/foreign/vips2webp.c
@@ -85,7 +85,8 @@ get_preset( VipsForeignWebpPreset preset )
 static int
 write_webp( WebPPicture *pic, VipsImage *in,
 	int Q, gboolean lossless, VipsForeignWebpPreset preset,
-	gboolean smart_subsample, gboolean near_lossless )
+	gboolean smart_subsample, gboolean near_lossless,
+	int alpha_q )
 {
 	VipsImage *memory;
 	WebPConfig config;
@@ -102,6 +103,7 @@ write_webp( WebPPicture *pic, VipsImage *in,
 		config.preprocessing |= 4;
 	if( near_lossless )
 		config.near_lossless = Q;
+	config.alpha_quality = alpha_q;
 
 	if( !WebPValidateConfig(&config) ) {
 		vips_error( "vips2webp",
@@ -147,7 +149,8 @@ write_webp( WebPPicture *pic, VipsImage *in,
 int
 vips__webp_write_file( VipsImage *in, const char *filename, 
 	int Q, gboolean lossless, VipsForeignWebpPreset preset,
-	gboolean smart_subsample, gboolean near_lossless )
+	gboolean smart_subsample, gboolean near_lossless,
+	int alpha_q )
 {
 	WebPPicture pic;
 	WebPMemoryWriter writer;
@@ -164,7 +167,7 @@ vips__webp_write_file( VipsImage *in, const char *filename,
 	pic.custom_ptr = &writer;
 
 	if( write_webp( &pic, in, Q, lossless, preset, smart_subsample,
-		near_lossless ) ) {
+		near_lossless, alpha_q ) ) {
 		WebPPictureFree( &pic );
 		WebPMemoryWriterClear( &writer );
 		return -1;
@@ -192,7 +195,8 @@ vips__webp_write_file( VipsImage *in, const char *filename,
 int
 vips__webp_write_buffer( VipsImage *in, void **obuf, size_t *olen, 
 	int Q, gboolean lossless, VipsForeignWebpPreset preset,
-	gboolean smart_subsample, gboolean near_lossless )
+	gboolean smart_subsample, gboolean near_lossless,
+	int alpha_q )
 {
 	WebPPicture pic;
 	WebPMemoryWriter writer;
@@ -209,7 +213,7 @@ vips__webp_write_buffer( VipsImage *in, void **obuf, size_t *olen,
 	pic.custom_ptr = &writer;
 
 	if( write_webp( &pic, in, Q, lossless, preset, smart_subsample,
-		near_lossless) ) {
+		near_lossless, alpha_q ) ) {
 		WebPPictureFree( &pic );
 		WebPMemoryWriterClear( &writer );
 		return -1;

--- a/libvips/foreign/vips2webp.c
+++ b/libvips/foreign/vips2webp.c
@@ -56,15 +56,41 @@
 typedef int (*webp_import)( WebPPicture *picture,
 	const uint8_t *rgb, int stride );
 
+static WebPPreset
+get_preset( VipsForeignWebpPreset preset )
+{
+	switch( preset ) {
+	case VIPS_FOREIGN_WEBP_PRESET_DEFAULT:
+		return( WEBP_PRESET_DEFAULT );
+	case VIPS_FOREIGN_WEBP_PRESET_PICTURE:
+		return( WEBP_PRESET_PICTURE );
+	case VIPS_FOREIGN_WEBP_PRESET_PHOTO:
+		return( WEBP_PRESET_PHOTO );
+	case VIPS_FOREIGN_WEBP_PRESET_DRAWING:
+		return( WEBP_PRESET_DRAWING );
+	case VIPS_FOREIGN_WEBP_PRESET_ICON:
+		return( WEBP_PRESET_ICON );
+	case VIPS_FOREIGN_WEBP_PRESET_TEXT:
+		return( WEBP_PRESET_TEXT );
+
+	default:
+		g_assert_not_reached();
+	}
+
+	/* Keep -Wall happy.
+	 */
+	return( -1 );
+}
+
 static int
 write_webp( WebPPicture *pic, VipsImage *in,
-	int Q, gboolean lossless )
+	int Q, gboolean lossless, VipsForeignWebpPreset preset )
 {
 	VipsImage *memory;
 	WebPConfig config;
 	webp_import import;
 
-	if ( !WebPConfigPreset(&config, WEBP_PRESET_DEFAULT, Q) ) {
+	if ( !WebPConfigPreset(&config, get_preset( preset ), Q) ) {
 		vips_error( "vips2webp",
 			"%s", _( "config version error" ) );
 		return( -1 );
@@ -112,7 +138,7 @@ write_webp( WebPPicture *pic, VipsImage *in,
 
 int
 vips__webp_write_file( VipsImage *in, const char *filename, 
-	int Q, gboolean lossless )
+	int Q, gboolean lossless, VipsForeignWebpPreset preset )
 {
 	WebPPicture pic;
 	WebPMemoryWriter writer;
@@ -128,7 +154,7 @@ vips__webp_write_file( VipsImage *in, const char *filename,
 	pic.writer = WebPMemoryWrite;
 	pic.custom_ptr = &writer;
 
-	if( write_webp( &pic, in, Q, lossless ) ) {
+	if( write_webp( &pic, in, Q, lossless, preset ) ) {
 		WebPPictureFree( &pic );
 		WebPMemoryWriterClear( &writer );
 		return -1;
@@ -155,7 +181,7 @@ vips__webp_write_file( VipsImage *in, const char *filename,
 
 int
 vips__webp_write_buffer( VipsImage *in, void **obuf, size_t *olen, 
-	int Q, gboolean lossless )
+	int Q, gboolean lossless, VipsForeignWebpPreset preset )
 {
 	WebPPicture pic;
 	WebPMemoryWriter writer;
@@ -171,7 +197,7 @@ vips__webp_write_buffer( VipsImage *in, void **obuf, size_t *olen,
 	pic.writer = WebPMemoryWrite;
 	pic.custom_ptr = &writer;
 
-	if( write_webp( &pic, in, Q, lossless ) ) {
+	if( write_webp( &pic, in, Q, lossless, preset ) ) {
 		WebPPictureFree( &pic );
 		WebPMemoryWriterClear( &writer );
 		return -1;

--- a/libvips/foreign/webp.h
+++ b/libvips/foreign/webp.h
@@ -49,9 +49,11 @@ int vips__webp_read_buffer( const void *buf, size_t len,
 	VipsImage *out, int shrink ); 
 
 int vips__webp_write_file( VipsImage *out, const char *filename, 
-	int Q, gboolean lossless, VipsForeignWebpPreset preset );
+	int Q, gboolean lossless, VipsForeignWebpPreset preset,
+	gboolean smart_subsample );
 int vips__webp_write_buffer( VipsImage *out, void **buf, size_t *len, 
-	int Q, gboolean lossless, VipsForeignWebpPreset preset );
+	int Q, gboolean lossless, VipsForeignWebpPreset preset,
+	gboolean smart_subsample );
 
 #ifdef __cplusplus
 }

--- a/libvips/foreign/webp.h
+++ b/libvips/foreign/webp.h
@@ -49,9 +49,9 @@ int vips__webp_read_buffer( const void *buf, size_t len,
 	VipsImage *out, int shrink ); 
 
 int vips__webp_write_file( VipsImage *out, const char *filename, 
-	int Q, gboolean lossless );
+	int Q, gboolean lossless, VipsForeignWebpPreset preset );
 int vips__webp_write_buffer( VipsImage *out, void **buf, size_t *len, 
-	int Q, gboolean lossless );
+	int Q, gboolean lossless, VipsForeignWebpPreset preset );
 
 #ifdef __cplusplus
 }

--- a/libvips/foreign/webp.h
+++ b/libvips/foreign/webp.h
@@ -50,10 +50,12 @@ int vips__webp_read_buffer( const void *buf, size_t len,
 
 int vips__webp_write_file( VipsImage *out, const char *filename, 
 	int Q, gboolean lossless, VipsForeignWebpPreset preset,
-	gboolean smart_subsample, gboolean near_lossless );
+	gboolean smart_subsample, gboolean near_lossless,
+	int alpha_q );
 int vips__webp_write_buffer( VipsImage *out, void **buf, size_t *len, 
 	int Q, gboolean lossless, VipsForeignWebpPreset preset,
-	gboolean smart_subsample, gboolean near_lossless );
+	gboolean smart_subsample, gboolean near_lossless,
+	int alpha_q );
 
 #ifdef __cplusplus
 }

--- a/libvips/foreign/webp.h
+++ b/libvips/foreign/webp.h
@@ -50,10 +50,10 @@ int vips__webp_read_buffer( const void *buf, size_t len,
 
 int vips__webp_write_file( VipsImage *out, const char *filename, 
 	int Q, gboolean lossless, VipsForeignWebpPreset preset,
-	gboolean smart_subsample );
+	gboolean smart_subsample, gboolean near_lossless );
 int vips__webp_write_buffer( VipsImage *out, void **buf, size_t *len, 
 	int Q, gboolean lossless, VipsForeignWebpPreset preset,
-	gboolean smart_subsample );
+	gboolean smart_subsample, gboolean near_lossless );
 
 #ifdef __cplusplus
 }

--- a/libvips/foreign/webpsave.c
+++ b/libvips/foreign/webpsave.c
@@ -68,6 +68,10 @@ typedef struct _VipsForeignSaveWebp {
 	 */
 	gboolean smart_subsample;
 
+	/* Use preprocessing in lossless mode.
+	 */
+	gboolean near_lossless;
+
 } VipsForeignSaveWebp;
 
 typedef VipsForeignSaveClass VipsForeignSaveWebpClass;
@@ -108,7 +112,7 @@ vips_foreign_save_webp_class_init( VipsForeignSaveWebpClass *class )
 		_( "Q factor" ),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET( VipsForeignSaveWebp, Q ),
-		1, 100, 75 );
+		0, 100, 75 );
 
 	VIPS_ARG_BOOL( class, "lossless", 11, 
 		_( "lossless" ), 
@@ -130,6 +134,13 @@ vips_foreign_save_webp_class_init( VipsForeignSaveWebpClass *class )
 		_( "Enable high quality chroma subsampling" ),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET( VipsForeignSaveWebp, smart_subsample ),
+		FALSE );
+
+	VIPS_ARG_BOOL( class, "near_lossless", 14,
+		_( "Near lossless" ),
+		_( "Enable preprocessing in lossless mode (uses Q)" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignSaveWebp, near_lossless ),
 		FALSE );
 
 }
@@ -167,7 +178,7 @@ vips_foreign_save_webp_file_build( VipsObject *object )
 
 	if( vips__webp_write_file( save->ready, file->filename, 
 		webp->Q, webp->lossless, webp->preset,
-		webp->smart_subsample ) )
+		webp->smart_subsample, webp->near_lossless ) )
 		return( -1 );
 
 	return( 0 );
@@ -230,7 +241,7 @@ vips_foreign_save_webp_buffer_build( VipsObject *object )
 
 	if( vips__webp_write_buffer( save->ready, &obuf, &olen, 
 		webp->Q, webp->lossless, webp->preset,
-		webp->smart_subsample ) )
+		webp->smart_subsample, webp->near_lossless ) )
 		return( -1 );
 
 	blob = vips_blob_new( (VipsCallbackFn) vips_free, obuf, olen );
@@ -292,7 +303,7 @@ vips_foreign_save_webp_mime_build( VipsObject *object )
 
 	if( vips__webp_write_buffer( save->ready, &obuf, &olen, 
 		webp->Q, webp->lossless, webp->preset,
-		webp->smart_subsample ) )
+		webp->smart_subsample, webp->near_lossless ) )
 		return( -1 );
 
 	printf( "Content-length: %zu\r\n", olen );

--- a/libvips/foreign/webpsave.c
+++ b/libvips/foreign/webpsave.c
@@ -72,6 +72,10 @@ typedef struct _VipsForeignSaveWebp {
 	 */
 	gboolean near_lossless;
 
+	/* Alpha quality.
+	 */
+	int alpha_q;
+
 } VipsForeignSaveWebp;
 
 typedef VipsForeignSaveClass VipsForeignSaveWebpClass;
@@ -143,12 +147,19 @@ vips_foreign_save_webp_class_init( VipsForeignSaveWebpClass *class )
 		G_STRUCT_OFFSET( VipsForeignSaveWebp, near_lossless ),
 		FALSE );
 
+	VIPS_ARG_INT( class, "alpha_q", 15,
+		_( "Alpha quality" ),
+		_( "Change alpha plane fidelity for lossy compression" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignSaveWebp, alpha_q ),
+		0, 100, 100 );
+
 }
 
 static void
 vips_foreign_save_webp_init( VipsForeignSaveWebp *webp )
 {
-	webp->Q = 80;
+	webp->Q = 75;
 }
 
 typedef struct _VipsForeignSaveWebpFile {
@@ -178,7 +189,8 @@ vips_foreign_save_webp_file_build( VipsObject *object )
 
 	if( vips__webp_write_file( save->ready, file->filename, 
 		webp->Q, webp->lossless, webp->preset,
-		webp->smart_subsample, webp->near_lossless ) )
+		webp->smart_subsample, webp->near_lossless,
+		webp->alpha_q ) )
 		return( -1 );
 
 	return( 0 );
@@ -241,7 +253,8 @@ vips_foreign_save_webp_buffer_build( VipsObject *object )
 
 	if( vips__webp_write_buffer( save->ready, &obuf, &olen, 
 		webp->Q, webp->lossless, webp->preset,
-		webp->smart_subsample, webp->near_lossless ) )
+		webp->smart_subsample, webp->near_lossless,
+		webp->alpha_q ) )
 		return( -1 );
 
 	blob = vips_blob_new( (VipsCallbackFn) vips_free, obuf, olen );
@@ -303,7 +316,8 @@ vips_foreign_save_webp_mime_build( VipsObject *object )
 
 	if( vips__webp_write_buffer( save->ready, &obuf, &olen, 
 		webp->Q, webp->lossless, webp->preset,
-		webp->smart_subsample, webp->near_lossless ) )
+		webp->smart_subsample, webp->near_lossless,
+		webp->alpha_q ) )
 		return( -1 );
 
 	printf( "Content-length: %zu\r\n", olen );

--- a/libvips/foreign/webpsave.c
+++ b/libvips/foreign/webpsave.c
@@ -64,6 +64,10 @@ typedef struct _VipsForeignSaveWebp {
 	 */
 	VipsForeignWebpPreset preset;
 
+	/* Enable smart chroma subsampling.
+	 */
+	gboolean smart_subsample;
+
 } VipsForeignSaveWebp;
 
 typedef VipsForeignSaveClass VipsForeignSaveWebpClass;
@@ -121,6 +125,13 @@ vips_foreign_save_webp_class_init( VipsForeignSaveWebpClass *class )
 		VIPS_TYPE_FOREIGN_WEBP_PRESET,
 		VIPS_FOREIGN_WEBP_PRESET_DEFAULT );
 
+	VIPS_ARG_BOOL( class, "smart_subsample", 13,
+		_( "Smart subsampling" ),
+		_( "Enable high quality chroma subsampling" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignSaveWebp, smart_subsample ),
+		FALSE );
+
 }
 
 static void
@@ -155,7 +166,8 @@ vips_foreign_save_webp_file_build( VipsObject *object )
 		return( -1 );
 
 	if( vips__webp_write_file( save->ready, file->filename, 
-		webp->Q, webp->lossless, webp->preset ) )
+		webp->Q, webp->lossless, webp->preset,
+		webp->smart_subsample ) )
 		return( -1 );
 
 	return( 0 );
@@ -217,7 +229,8 @@ vips_foreign_save_webp_buffer_build( VipsObject *object )
 		return( -1 );
 
 	if( vips__webp_write_buffer( save->ready, &obuf, &olen, 
-		webp->Q, webp->lossless, webp->preset ) )
+		webp->Q, webp->lossless, webp->preset,
+		webp->smart_subsample ) )
 		return( -1 );
 
 	blob = vips_blob_new( (VipsCallbackFn) vips_free, obuf, olen );
@@ -278,7 +291,8 @@ vips_foreign_save_webp_mime_build( VipsObject *object )
 		return( -1 );
 
 	if( vips__webp_write_buffer( save->ready, &obuf, &olen, 
-		webp->Q, webp->lossless, webp->preset ) )
+		webp->Q, webp->lossless, webp->preset,
+		webp->smart_subsample ) )
 		return( -1 );
 
 	printf( "Content-length: %zu\r\n", olen );

--- a/libvips/foreign/webpsave.c
+++ b/libvips/foreign/webpsave.c
@@ -60,6 +60,10 @@ typedef struct _VipsForeignSaveWebp {
 	 */
 	gboolean lossless;
 
+	/* Lossy compression preset.
+	 */
+	VipsForeignWebpPreset preset;
+
 } VipsForeignSaveWebp;
 
 typedef VipsForeignSaveClass VipsForeignSaveWebpClass;
@@ -109,6 +113,14 @@ vips_foreign_save_webp_class_init( VipsForeignSaveWebpClass *class )
 		G_STRUCT_OFFSET( VipsForeignSaveWebp, lossless ),
 		FALSE ); 
 
+	VIPS_ARG_ENUM( class, "preset", 12,
+		_( "preset" ),
+		_( "Preset for lossy compression" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignSaveWebp, preset ),
+		VIPS_TYPE_FOREIGN_WEBP_PRESET,
+		VIPS_FOREIGN_WEBP_PRESET_DEFAULT );
+
 }
 
 static void
@@ -143,7 +155,7 @@ vips_foreign_save_webp_file_build( VipsObject *object )
 		return( -1 );
 
 	if( vips__webp_write_file( save->ready, file->filename, 
-		webp->Q, webp->lossless ) )
+		webp->Q, webp->lossless, webp->preset ) )
 		return( -1 );
 
 	return( 0 );
@@ -205,7 +217,7 @@ vips_foreign_save_webp_buffer_build( VipsObject *object )
 		return( -1 );
 
 	if( vips__webp_write_buffer( save->ready, &obuf, &olen, 
-		webp->Q, webp->lossless ) )
+		webp->Q, webp->lossless, webp->preset ) )
 		return( -1 );
 
 	blob = vips_blob_new( (VipsCallbackFn) vips_free, obuf, olen );
@@ -266,7 +278,7 @@ vips_foreign_save_webp_mime_build( VipsObject *object )
 		return( -1 );
 
 	if( vips__webp_write_buffer( save->ready, &obuf, &olen, 
-		webp->Q, webp->lossless ) )
+		webp->Q, webp->lossless, webp->preset ) )
 		return( -1 );
 
 	printf( "Content-length: %zu\r\n", olen );

--- a/libvips/include/vips/enumtypes.h
+++ b/libvips/include/vips/enumtypes.h
@@ -14,6 +14,8 @@ GType vips_foreign_flags_get_type (void) G_GNUC_CONST;
 #define VIPS_TYPE_FOREIGN_FLAGS (vips_foreign_flags_get_type())
 GType vips_saveable_get_type (void) G_GNUC_CONST;
 #define VIPS_TYPE_SAVEABLE (vips_saveable_get_type())
+GType vips_foreign_webp_preset_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_FOREIGN_WEBP_PRESET (vips_foreign_webp_preset_get_type())
 GType vips_foreign_tiff_compression_get_type (void) G_GNUC_CONST;
 #define VIPS_TYPE_FOREIGN_TIFF_COMPRESSION (vips_foreign_tiff_compression_get_type())
 GType vips_foreign_tiff_predictor_get_type (void) G_GNUC_CONST;

--- a/libvips/include/vips/foreign.h
+++ b/libvips/include/vips/foreign.h
@@ -338,6 +338,29 @@ int vips_jpegsave_buffer( VipsImage *in, void **buf, size_t *len, ... )
 int vips_jpegsave_mime( VipsImage *in, ... )
 	__attribute__((sentinel));
 
+/**
+ * VipsForeignWebpPreset:
+ * @VIPS_FOREIGN_WEBP_PRESET_DEFAULT: default preset
+ * @VIPS_FOREIGN_WEBP_PRESET_PICTURE: digital picture, like portrait,
+ * inner shot
+ * @VIPS_FOREIGN_WEBP_PRESET_PHOTO: outdoor photograph, with natural lighting
+ * @VIPS_FOREIGN_WEBP_PRESET_DRAWING: hand or line drawing, with high-contrast
+ * details
+ * @VIPS_FOREIGN_WEBP_PRESET_ICON: small-sized colorful images
+ * @VIPS_FOREIGN_WEBP_PRESET_TEXT: text-like
+ *
+ * Tune lossy encoder settings for different image types.
+ */
+typedef enum {
+	VIPS_FOREIGN_WEBP_PRESET_DEFAULT,
+	VIPS_FOREIGN_WEBP_PRESET_PICTURE,
+	VIPS_FOREIGN_WEBP_PRESET_PHOTO,
+	VIPS_FOREIGN_WEBP_PRESET_DRAWING,
+	VIPS_FOREIGN_WEBP_PRESET_ICON,
+	VIPS_FOREIGN_WEBP_PRESET_TEXT,
+	VIPS_FOREIGN_WEBP_PRESET_LAST
+} VipsForeignWebpPreset;
+
 int vips_webpload( const char *filename, VipsImage **out, ... )
 	__attribute__((sentinel));
 int vips_webpload_buffer( void *buf, size_t len, VipsImage **out, ... )

--- a/libvips/iofuncs/enumtypes.c
+++ b/libvips/iofuncs/enumtypes.c
@@ -70,6 +70,28 @@ vips_saveable_get_type( void )
 	return( etype );
 }
 GType
+vips_foreign_webp_preset_get_type( void )
+{
+	static GType etype = 0;
+
+	if( etype == 0 ) {
+		static const GEnumValue values[] = {
+			{VIPS_FOREIGN_WEBP_PRESET_DEFAULT, "VIPS_FOREIGN_WEBP_PRESET_DEFAULT", "default"},
+			{VIPS_FOREIGN_WEBP_PRESET_PICTURE, "VIPS_FOREIGN_WEBP_PRESET_PICTURE", "picture"},
+			{VIPS_FOREIGN_WEBP_PRESET_PHOTO, "VIPS_FOREIGN_WEBP_PRESET_PHOTO", "photo"},
+			{VIPS_FOREIGN_WEBP_PRESET_DRAWING, "VIPS_FOREIGN_WEBP_PRESET_DRAWING", "drawing"},
+			{VIPS_FOREIGN_WEBP_PRESET_ICON, "VIPS_FOREIGN_WEBP_PRESET_ICON", "icon"},
+			{VIPS_FOREIGN_WEBP_PRESET_TEXT, "VIPS_FOREIGN_WEBP_PRESET_TEXT", "text"},
+			{VIPS_FOREIGN_WEBP_PRESET_LAST, "VIPS_FOREIGN_WEBP_PRESET_LAST", "last"},
+			{0, NULL, NULL}
+		};
+		
+		etype = g_enum_register_static( "VipsForeignWebpPreset", values );
+	}
+
+	return( etype );
+}
+GType
 vips_foreign_tiff_compression_get_type( void )
 {
 	static GType etype = 0;

--- a/test/test_formats.sh
+++ b/test/test_formats.sh
@@ -186,6 +186,10 @@ fi
 if test_supported jpegload; then
 	test_format $image jpg 90
 fi
+if test_supported webpload; then
+	test_format $image webp 90
+	test_format $image webp 0 [lossless]
+fi
 test_format $image ppm 0
 test_format $image pfm 0
 if test_supported fitsload; then
@@ -220,4 +224,3 @@ if test_supported dzsave; then
 	test_saver copy $image .dz
 	test_saver copy $image .dz[container=zip]
 fi
-


### PR DESCRIPTION
* Switch to WebP Advanced Encoding API to allow access to `WebPConfig`
* Add `preset` enumerable to tune WebP lossy compression for certain types of images
* Add `smart_subsample` switch that greatly reduces color bleeding from 4:2:0 subsampling
* Add `near_lossless` switch that allows preprocessing in lossless mode using `Q` option
* Add `alphaQ` option similar to `Q` that allows to reduce alpha palette in lossy mode