### PR TITLE
Fix configure check for giflib4

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -631,14 +631,26 @@ if test "$GIFLIB_LIBS" = ""; then
   INCLUDES="$GIFLIB_INCLUDES $INCLUDES"
 
   # Try the standard search path first
-  AC_TRY_LINK([#include <gif_lib.h>],[EGifSetGifVersion(0,0)], [
+  AC_TRY_LINK([#include <gif_lib.h>],[
+    #if defined(GIFLIB_MAJOR) && GIFLIB_MAJOR > 4
+    EGifSetGifVersion(0,0);
+    #else
+    GifLastError();
+    #endif
+  ], [
     GIFLIB_LIBS="-lgif"
   ], [
     # giflib is not in the standard search path, try $prefix
 
     LIBS="-L${prefix}/lib $LIBS"
 
-    AC_TRY_LINK([#include <gif_lib.h>],[EGifSetGifVersion(0,0)], [
+    AC_TRY_LINK([#include <gif_lib.h>],[
+      #if defined(GIFLIB_MAJOR) && GIFLIB_MAJOR > 4
+      EGifSetGifVersion(0,0);
+      #else
+      GifLastError();
+      #endif
+    ], [
       GIFLIB_LIBS="-L${prefix}/lib -lgif"
     ], [
       GIFLIB_LIBS=no


### PR DESCRIPTION
This uses a combination of the old giflib4 and the new giflib5 checks.

Fixes #435.