### PR TITLE
Fix threading and thumbnail tests without make install

### DIFF
--- a/test/test_threading.sh
+++ b/test/test_threading.sh
@@ -7,22 +7,22 @@
 chain=1
 
 # im_benchmark needs a labq
-vips colourspace $image $tmp/t3.v labq
+$vips colourspace $image $tmp/t3.v labq
 
 for tile in 10 64 128 512; do
 	# benchmark includes a dither which will vary with tile size
-	vips --vips-concurrency=1 \
+	$vips --vips-concurrency=1 \
 		--vips-tile-width=$tile --vips-tile-height=$tile \
 		im_benchmarkn $tmp/t3.v $tmp/t5.v $chain
 
 	for cpus in 2 3 4 5 6 7 8 99; do
 		echo trying cpus = $cpus, tile = $tile ...
-		vips --vips-concurrency=$cpus \
+		$vips --vips-concurrency=$cpus \
 			--vips-tile-width=$tile --vips-tile-height=$tile \
 			im_benchmarkn $tmp/t3.v $tmp/t7.v $chain
-		vips subtract $tmp/t5.v $tmp/t7.v $tmp/t8.v
-		vips abs $tmp/t8.v $tmp/t9.v
-		max=$(vips max $tmp/t9.v)
+		$vips subtract $tmp/t5.v $tmp/t7.v $tmp/t8.v
+		$vips abs $tmp/t8.v $tmp/t9.v
+		max=$($vips max $tmp/t9.v)
 		if [ $(echo "$max > 0" | bc) -eq 1 ]; then
 			break
 		fi

--- a/test/test_thumbnail.sh
+++ b/test/test_thumbnail.sh
@@ -11,10 +11,10 @@
 # make a 1000x1000 mono test image ... add a bit so the image should not 
 # contain any zeros, helps to spot missing tiles and bad pixels
 echo building test image ...
-vips extract_band $image $tmp/t1.v 1
-vips linear $tmp/t1.v $tmp/t2.v 1 20 --uchar
-vips replicate $tmp/t2.v $tmp/t1.v 2 2
-vips crop $tmp/t1.v $tmp/t2.v 10 10 1000 1000
+$vips extract_band $image $tmp/t1.v 1
+$vips linear $tmp/t1.v $tmp/t2.v 1 20 --uchar
+$vips replicate $tmp/t2.v $tmp/t1.v 2 2
+$vips crop $tmp/t1.v $tmp/t2.v 10 10 1000 1000
 
 # is a difference beyond a threshold? return 0 (meaning all ok) or 1 (meaning
 # error, or outside threshold)
@@ -27,33 +27,33 @@ break_threshold() {
 size=1000
 while [ $size -gt 99 ]; do
 	printf "testing size to $size ... "
-	vipsthumbnail $tmp/t2.v -o $tmp/t1.v --size $size 
-	if [ $(vipsheader -f width $tmp/t1.v) -ne $size ]; then
+	$vipsthumbnail $tmp/t2.v -o $tmp/t1.v --size $size 
+	if [ $($vipsheader -f width $tmp/t1.v) -ne $size ]; then
 		echo $tmp/t1.v failed -- bad size
-		echo output width is $(vipsheader -f width $tmp/t1.v) 
+		echo output width is $($vipsheader -f width $tmp/t1.v) 
 		exit
 	fi
-	if [ $(vipsheader -f height $tmp/t1.v) -ne $size ]; then
+	if [ $($vipsheader -f height $tmp/t1.v) -ne $size ]; then
 		echo $tmp/t1.v failed -- bad size
-		echo output height is $(vipsheader -f width $tmp/t1.v) 
+		echo output height is $($vipsheader -f width $tmp/t1.v) 
 		exit
 	fi
 
-	vips project $tmp/t1.v $tmp/cols.v $tmp/rows.v
+	$vips project $tmp/t1.v $tmp/cols.v $tmp/rows.v
 
-	min=$(vips min $tmp/cols.v)
+	min=$($vips min $tmp/cols.v)
 	if break_threshold $min 0; then
 		echo $tmp/t1.v failed -- has a black column
 		exit
 	fi
 
-	min=$(vips min $tmp/rows.v)
+	min=$($vips min $tmp/rows.v)
 	if break_threshold $min 0; then
 		echo $tmp/t1.v failed -- has a black row
 		exit
 	fi
 
-	min=$(vips min $tmp/t1.v)
+	min=$($vips min $tmp/t1.v)
 	if break_threshold $min 0; then
 		echo $tmp/t1.v failed -- has black pixels
 		exit


### PR DESCRIPTION
Both scripts were not using the $vips variables required to use vips from the source directory instead of from the system.