### PR TITLE
Test system webp on Travis CI and fix alpha_q default value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: cpp
 before_install:
-  - sudo add-apt-repository ppa:lyrasis/precise-backports -y
   - sudo apt-get update -qq
   - sudo apt-get install automake gtk-doc-tools 
   - sudo apt-get install gobject-introspection

--- a/libvips/foreign/webpsave.c
+++ b/libvips/foreign/webpsave.c
@@ -160,6 +160,7 @@ static void
 vips_foreign_save_webp_init( VipsForeignSaveWebp *webp )
 {
 	webp->Q = 75;
+	webp->alpha_q = 100;
 }
 
 typedef struct _VipsForeignSaveWebpFile {

--- a/test/test_formats.sh
+++ b/test/test_formats.sh
@@ -192,7 +192,6 @@ if test_supported jpegload; then
 fi
 if test_supported webpload; then
 	test_format $image webp 90
-	test_format $image webp 0 [lossless]
 fi
 test_format $image ppm 0
 test_format $image pfm 0


### PR DESCRIPTION
This switches from the current backport ppa to testing against the system provides libwebp-0.1.3 on Travis CI. As a consequence the lossless test in `test_formats.sh` was dropped, because it's not supported on that old version.

I've also fixed the default value for webpsave `alpha_q` to be 100 instead of 0. I had assumed that would be already handled by defining the `VIPS_ARG_INT`, but that doesn't seem to be the case.