### PR TITLE
Fix Python and GI path detection problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,8 @@ libtool
 libvips/include/vips/version.h
 fred
 ltmain.sh
-m4/
+m4/*
+!m4/python.m4
 missing
 mkinstalldirs
 po/Makefile.in.in

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,7 +5,7 @@
 # a bunch of cleaning up ... make certain everything will be regenerated
 rm -f Makefile Makefile.in aclocal.m4 
 rm -rf autom4te.cache
-rm -f m4/*
+find m4 ! -name python.m4 -type f -name '*.m4' -delete
 rm -f config.* configure depcomp
 rm -f install-sh intltool-* libtool ltmain.sh missing mkinstalldirs
 rm -f stamp-* vipsCC-7.19.pc vips-7.19.spec vips-7.19.pc
@@ -31,7 +31,6 @@ if [ -e $ACDIR/dirlist ]; then
   ACDIR=`cat $ACDIR/dirlist`
 fi
 
-mkdir -p m4
 # glib-gettextize asks us to copy these files to m4 if they aren't there:
 files="codeset gettext glibc21 iconv isc-posix lcmessage progtest introspection"
 for dir in $ACDIR; do
@@ -58,7 +57,7 @@ test -r aclocal.m4 || touch aclocal.m4
 glib-gettextize --force --copy > /dev/null
 test -r aclocal.m4 && chmod u+w aclocal.m4
 # intltoolize --copy --force --automake
-aclocal
+aclocal -I m4
 autoconf
 autoheader
 $LIBTOOLIZE --copy --force --automake

--- a/configure.ac
+++ b/configure.ac
@@ -1016,8 +1016,21 @@ if test x"$enable_pyvips8" = xyes; then
     /usr/local/Cellar/vips/*)
       ;; # ingnore for homebrew
     *)
-      syspygipath=`$PYTHON -c "import sys;sys.path.append('$VIPS_PYEXECDIR');import gi;print(gi._overridesdir)"`
-      if test x"$VIPS_PYEXECDIR/gi/overrides" != x"$syspygipath"; then
+      syspygipath=`$PYTHON -c "
+import sys
+sys.path.append('$VIPS_PYEXECDIR')
+try: import gi; print(gi._overridesdir)
+except: pass"`
+      if test x"$syspygipath" = x; then
+        AC_MSG_RESULT([dnl
+Your python gi module could not be loaded.
+
+You should change your PYTHONPATH environment
+variable to include the pygobject3 gi module
+and re-run configure to check if the Vips.py
+overrides are installed in the correct location.
+        ])
+      elif test x"$VIPS_PYEXECDIR/gi/overrides" != x"$syspygipath"; then
         AC_MSG_RESULT([dnl
 The vips Python overrides file will install to 
 $VIPS_PYEXECDIR/gi/overrides/Vips.py, but your

--- a/configure.ac
+++ b/configure.ac
@@ -260,6 +260,7 @@ AM_WITH_DMALLOC
 # without this we get something like
 #    define VIPS_LIBDIR ${exec_prefix}/lib
 # argh
+test "x$prefix" = xNONE && prefix=$ac_default_prefix
 test "x$exec_prefix" = xNONE && exec_prefix='${prefix}'
 
 # set $expanded_value to the fully-expanded value of the argument

--- a/configure.ac
+++ b/configure.ac
@@ -986,28 +986,39 @@ use libexif to load/save JPEG metadata: $with_libexif
 ])
 
 if test x"$found_introspection" = xyes -a "$VIPS_LIBDIR/girepository-1.0" != "$INTROSPECTION_TYPELIBDIR"; then
-  AC_MSG_RESULT([dnl
+  case "$VIPS_LIBDIR" in
+    /usr/local/Cellar/vips/*)
+      ;; # ingnore for homebrew
+    *)
+      AC_MSG_RESULT([dnl
 Vips-8.0.typelib will install to $VIPS_LIBDIR/girepository-1.0, but your
 system repository seems to be $INTROSPECTION_TYPELIBDIR. 
 You may need to add this directory to your typelib path, for example:
 
 	export GI_TYPELIB_PATH="$VIPS_LIBDIR/girepository-1.0"
-  ])
+      ])
+      ;;
+  esac
 fi
 
-expand $pyexecdir
-VIPS_PYEXECDIR=$expanded_value
-
-inpath=`$PYTHON -c "import gi;print('$VIPS_PYEXECDIR/gi' in gi.__path__)"`
-syspygipath=`$PYTHON -c "import gi;print(gi.__path__@<:@-1@:>@)"`
-
-if test x"$enable_pyvips8" = xyes -a x"$inpath" != x"True"; then
-  AC_MSG_RESULT([dnl
+if test x"$enable_pyvips8" = xyes; then
+  expand $pyexecdir
+  VIPS_PYEXECDIR=$expanded_value
+  case "$VIPS_PYEXECDIR" in
+    /usr/local/Cellar/vips/*)
+      ;; # ingnore for homebrew
+    *)
+      syspygipath=`$PYTHON -c "import sys;sys.path.append('$VIPS_PYEXECDIR');import gi;print(gi._overridesdir)"`
+      if test x"$VIPS_PYEXECDIR/gi/overrides" != x"$syspygipath"; then
+        AC_MSG_RESULT([dnl
 The vips Python overrides file will install to 
-$VIPS_PYEXECDIR/overrides/Vips.py, but your
-system gi area seems to be $syspygipath.
+$VIPS_PYEXECDIR/gi/overrides/Vips.py, but your
+system gi overrides seem to be $syspygipath.
 You may need to copy this file, for example:
 
-	cp $VIPS_PYEXECDIR/overrides/Vips.* $syspygipath/overrides
-  ])
+	cp $VIPS_PYEXECDIR/gi/overrides/Vips.* $syspygipath
+        ])
+      fi
+      ;;
+  esac
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -726,7 +726,7 @@ if test "x$enable_pyvips8" = "xauto"; then
 fi
 
 if test x"$enable_pyvips8" = x"yes"; then
-  AM_PATH_PYTHON(2.7,,
+  JD_PATH_PYTHON(2.7,,
     [enable_pyvips8=no
      AC_MSG_WARN([Python not found; disabling vips8 Python binding])]
   )
@@ -846,7 +846,7 @@ if test x"$with_python" != x"no"; then
 fi
 
 if test x"$with_python" != x"no"; then
-  AM_PATH_PYTHON(2.7,,
+  JD_PATH_PYTHON(2.7,,
     [with_python=no
      AC_MSG_WARN([Python not found; disabling vips7 Python binding])]
   )

--- a/configure.ac
+++ b/configure.ac
@@ -848,7 +848,15 @@ fi
 if test x"$with_python" != x"no"; then
   JD_PATH_PYTHON(2.7,,
     [with_python=no
-     AC_MSG_WARN([Python not found; disabling vips7 Python binding])]
+     AC_MSG_WARN([Python >= 2.7 not found; disabling vips7 Python binding])]
+  )
+fi
+
+if test x"$with_python" != x"no"; then
+  # The SWIG bindings don't compile on python3 (see issue #334).
+  AM_PYTHON_CHECK_VERSION([$PYTHON], [3.0],
+    [with_python=no
+     AC_MSG_WARN([Python >= 3.0 found; disabling vips7 Python binding])]
   )
 fi
 

--- a/m4/python.m4
+++ b/m4/python.m4
@@ -1,0 +1,239 @@
+## Imported from pygobject at commit 5737a9ec4bf4d9d07a7e3994d91abf9077b342cc.
+## Automake's built-in version has problems on multiarch systems.
+## this one is commonly used with AM_PATH_PYTHONDIR ...
+dnl AM_CHECK_PYMOD(MODNAME [,SYMBOL [,ACTION-IF-FOUND [,ACTION-IF-NOT-FOUND]]])
+dnl Check if a module containing a given symbol is visible to python.
+AC_DEFUN([AM_CHECK_PYMOD],
+[AC_REQUIRE([AM_PATH_PYTHON])
+py_mod_var=`echo $1['_']$2 | sed 'y%./+-%__p_%'`
+AC_MSG_CHECKING(for ifelse([$2],[],,[$2 in ])python module $1)
+AC_CACHE_VAL(py_cv_mod_$py_mod_var, [
+ifelse([$2],[], [prog="
+import sys
+try:
+        import $1
+except ImportError:
+        sys.exit(1)
+except:
+        sys.exit(0)
+sys.exit(0)"], [prog="
+import $1
+$1.$2"])
+if $PYTHON -c "$prog" 1>&AC_FD_CC 2>&AC_FD_CC
+  then
+    eval "py_cv_mod_$py_mod_var=yes"
+  else
+    eval "py_cv_mod_$py_mod_var=no"
+  fi
+])
+py_val=`eval "echo \`echo '$py_cv_mod_'$py_mod_var\`"`
+if test "x$py_val" != xno; then
+  AC_MSG_RESULT(yes)
+  ifelse([$3], [],, [$3
+])dnl
+else
+  AC_MSG_RESULT(no)
+  ifelse([$4], [],, [$4
+])dnl
+fi
+])
+
+dnl a macro to check for ability to create python extensions
+dnl  AM_CHECK_PYTHON_HEADERS([ACTION-IF-POSSIBLE], [ACTION-IF-NOT-POSSIBLE])
+dnl function also defines PYTHON_INCLUDES
+AC_DEFUN([AM_CHECK_PYTHON_HEADERS],
+[AC_REQUIRE([AM_PATH_PYTHON])
+AC_MSG_CHECKING(for headers required to compile python extensions)
+dnl deduce PYTHON_INCLUDES
+if test "x$PYTHON_INCLUDES" = x; then
+  PYTHON_CONFIG=`which $PYTHON`-config
+  if test -x "$PYTHON_CONFIG"; then
+    PYTHON_INCLUDES=`$PYTHON_CONFIG --includes 2>/dev/null`
+  else
+    PYTHON_INCLUDES=`$PYTHON -c "import distutils.sysconfig, sys; sys.stdout.write(distutils.sysconfig.get_python_inc(True))"`
+    PYTHON_INCLUDES="-I$PYTHON_INCLUDES"
+  fi
+fi
+AC_SUBST(PYTHON_INCLUDES)
+dnl check if the headers exist:
+save_CPPFLAGS="$CPPFLAGS"
+CPPFLAGS="$CPPFLAGS $PYTHON_INCLUDES"
+AC_TRY_CPP([#include <Python.h>],dnl
+[AC_MSG_RESULT(found)
+$1],dnl
+[AC_MSG_RESULT(not found)
+$2])
+CPPFLAGS="$save_CPPFLAGS"
+])
+
+dnl a macro to check for ability to embed python
+dnl  AM_CHECK_PYTHON_LIBS([ACTION-IF-POSSIBLE], [ACTION-IF-NOT-POSSIBLE])
+dnl function also defines PYTHON_LIBS
+AC_DEFUN([AM_CHECK_PYTHON_LIBS],
+[AC_REQUIRE([AM_PATH_PYTHON])
+AC_MSG_CHECKING(for libraries required to embed python)
+dnl deduce PYTHON_LIBS
+py_prefix=`$PYTHON -c "import sys; sys.stdout.write(sys.prefix)"`
+if test "x$PYTHON_LIBS" = x; then
+  PYTHON_CONFIG=`which $PYTHON`-config
+  if test -x "$PYTHON_CONFIG"; then
+    PYTHON_LIBS=`$PYTHON_CONFIG --ldflags 2>/dev/null`
+  else
+    PYTHON_LIBS="-L${py_prefix}/lib -lpython${PYTHON_VERSION}"
+  fi
+fi
+if test "x$PYTHON_LIB_LOC" = x; then
+	PYTHON_LIB_LOC="${py_prefix}/lib"
+fi
+AC_SUBST(PYTHON_LIBS)
+AC_SUBST(PYTHON_LIB_LOC)
+dnl check if the headers exist:
+save_LIBS="$LIBS"
+LIBS="$LIBS $PYTHON_LIBS"
+AC_TRY_LINK_FUNC(Py_Initialize, dnl
+         [LIBS="$save_LIBS"; AC_MSG_RESULT(yes); $1], dnl
+         [LIBS="$save_LIBS"; AC_MSG_RESULT(no); $2])
+
+])
+
+# Copyright (C) 1999, 2000, 2001, 2002, 2003, 2004, 2005
+# Free Software Foundation, Inc.
+#
+# This file is free software; the Free Software Foundation
+# gives unlimited permission to copy and/or distribute it,
+# with or without modifications, as long as this notice is preserved.
+
+# JD_PATH_PYTHON([MINIMUM-VERSION], [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])
+# ---------------------------------------------------------------------------
+# Adds support for distributing Python modules and packages.  To
+# install modules, copy them to $(pythondir), using the python_PYTHON
+# automake variable.  To install a package with the same name as the
+# automake package, install to $(pkgpythondir), or use the
+# pkgpython_PYTHON automake variable.
+#
+# The variables $(pyexecdir) and $(pkgpyexecdir) are provided as
+# locations to install python extension modules (shared libraries).
+# Another macro is required to find the appropriate flags to compile
+# extension modules.
+#
+# If your package is configured with a different prefix to python,
+# users will have to add the install directory to the PYTHONPATH
+# environment variable, or create a .pth file (see the python
+# documentation for details).
+#
+# If the MINIMUM-VERSION argument is passed, AM_PATH_PYTHON will
+# cause an error if the version of python installed on the system
+# doesn't meet the requirement.  MINIMUM-VERSION should consist of
+# numbers and dots only.
+AC_DEFUN([JD_PATH_PYTHON],
+ [
+  dnl Find a Python interpreter.  Python versions prior to 2.0 are not
+  dnl supported
+  m4_define_default([_AM_PYTHON_INTERPRETER_LIST],
+                    [python python2 python2.7 python3 python3.5 python3.4 python3.3 python3.2 python3.1 python3.0])
+
+  m4_if([$1],[],[
+    dnl No version check is needed.
+    # Find any Python interpreter.
+    if test -z "$PYTHON"; then
+      AC_PATH_PROGS([PYTHON], _AM_PYTHON_INTERPRETER_LIST, :)
+    fi
+    am_display_PYTHON=python
+  ], [
+    dnl A version check is needed.
+    if test -n "$PYTHON"; then
+      # If the user set $PYTHON, use it and don't search something else.
+      AC_MSG_CHECKING([whether $PYTHON version >= $1])
+      AM_PYTHON_CHECK_VERSION([$PYTHON], [$1],
+			      [AC_MSG_RESULT(yes)],
+			      [AC_MSG_ERROR(too old)])
+      am_display_PYTHON=$PYTHON
+    else
+      # Otherwise, try each interpreter until we find one that satisfies
+      # VERSION.
+      AC_CACHE_CHECK([for a Python interpreter with version >= $1],
+	[am_cv_pathless_PYTHON],[
+	for am_cv_pathless_PYTHON in _AM_PYTHON_INTERPRETER_LIST none; do
+	  test "$am_cv_pathless_PYTHON" = none && break
+	  AM_PYTHON_CHECK_VERSION([$am_cv_pathless_PYTHON], [$1], [break])
+	done])
+      # Set $PYTHON to the absolute path of $am_cv_pathless_PYTHON.
+      if test "$am_cv_pathless_PYTHON" = none; then
+	PYTHON=:
+      else
+        AC_PATH_PROG([PYTHON], [$am_cv_pathless_PYTHON])
+      fi
+      am_display_PYTHON=$am_cv_pathless_PYTHON
+    fi
+  ])
+
+  if test "$PYTHON" = :; then
+  dnl Run any user-specified action, or abort.
+    m4_default([$3], [AC_MSG_ERROR([no suitable Python interpreter found])])
+  else
+
+  dnl Query Python for its version number.  Getting [:3] seems to be
+  dnl the best way to do this; it's what "site.py" does in the standard
+  dnl library.
+
+  AC_CACHE_CHECK([for $am_display_PYTHON version], [am_cv_python_version],
+    [am_cv_python_version=`$PYTHON -c "import sys; sys.stdout.write(sys.version[[:3]])"`])
+  AC_SUBST([PYTHON_VERSION], [$am_cv_python_version])
+
+  dnl Use the values of $prefix and $exec_prefix for the corresponding
+  dnl values of PYTHON_PREFIX and PYTHON_EXEC_PREFIX.  These are made
+  dnl distinct variables so they can be overridden if need be.  However,
+  dnl general consensus is that you shouldn't need this ability.
+
+  AC_SUBST([PYTHON_PREFIX], ['${prefix}'])
+  AC_SUBST([PYTHON_EXEC_PREFIX], ['${exec_prefix}'])
+
+  dnl At times (like when building shared libraries) you may want
+  dnl to know which OS platform Python thinks this is.
+
+  AC_CACHE_CHECK([for $am_display_PYTHON platform], [am_cv_python_platform],
+    [am_cv_python_platform=`$PYTHON -c "import sys; sys.stdout.write(sys.platform)"`])
+  AC_SUBST([PYTHON_PLATFORM], [$am_cv_python_platform])
+
+
+  dnl Set up 4 directories:
+
+  dnl pythondir -- where to install python scripts.  This is the
+  dnl   site-packages directory, not the python standard library
+  dnl   directory like in previous automake betas.  This behavior
+  dnl   is more consistent with lispdir.m4 for example.
+  dnl Query distutils for this directory.  distutils does not exist in
+  dnl Python 1.5, so we fall back to the hardcoded directory if it
+  dnl doesn't work.
+  AC_CACHE_CHECK([for $am_display_PYTHON script directory],
+    [am_cv_python_pythondir],
+    [am_cv_python_pythondir=`$PYTHON -c "from distutils import sysconfig; print(sysconfig.get_python_lib(0,0,prefix='$PYTHON_PREFIX'))" 2>/dev/null ||
+     echo "$PYTHON_PREFIX/lib/python$PYTHON_VERSION/site-packages"`])
+  AC_SUBST([pythondir], [$am_cv_python_pythondir])
+
+  dnl pkgpythondir -- $PACKAGE directory under pythondir.  Was
+  dnl   PYTHON_SITE_PACKAGE in previous betas, but this naming is
+  dnl   more consistent with the rest of automake.
+
+  AC_SUBST([pkgpythondir], [\${pythondir}/$PACKAGE])
+
+  dnl pyexecdir -- directory for installing python extension modules
+  dnl   (shared libraries)
+  dnl Query distutils for this directory.  distutils does not exist in
+  dnl Python 1.5, so we fall back to the hardcoded directory if it
+  dnl doesn't work.
+  AC_CACHE_CHECK([for $am_display_PYTHON extension module directory],
+    [am_cv_python_pyexecdir],
+    [am_cv_python_pyexecdir=`$PYTHON -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,0,prefix='$PYTHON_EXEC_PREFIX'))" 2>/dev/null ||
+     echo "${PYTHON_EXEC_PREFIX}/lib/python${PYTHON_VERSION}/site-packages"`])
+  AC_SUBST([pyexecdir], [$am_cv_python_pyexecdir])
+
+  dnl pkgpyexecdir -- $(pyexecdir)/$(PACKAGE)
+
+  AC_SUBST([pkgpyexecdir], [\${pyexecdir}/$PACKAGE])
+
+  dnl Run any user-specified action.
+  $2
+  fi
+
+])


### PR DESCRIPTION
* Vendor the pygobject `m4/python.m4` to fix wrong multiarch exec paths
* Fix several problems with gi path warnings
* Disable vips7 SWIG bindings for python3 (see #334)
* Warn if the gi module could not be loaded
* Fix `VIPS_LIBDIR` being `"NONE"` without explicit `--prefix`

For details see #438 and the individual commit messages.