### PR TITLE
Use printf instead of non-portable echo -n in bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -42,7 +42,7 @@ fi
 gtkdocize --copy --docdir doc --flavour no-tmpl || exit 1
 
 # some systems need libtoolize, some glibtoolize ... how annoying
-echo -n "testing for glibtoolize ... "
+printf "testing for glibtoolize ... "
 if glibtoolize --version >/dev/null 2>&1; then
   LIBTOOLIZE=glibtoolize
   echo using glibtoolize


### PR DESCRIPTION
Not all versions of echo support `-n` so using it is not portable. One example where this does not work is bash in sh mode on Mac OS X. Replaced with `printf` which the BSD manpage suggest to use for portability.