### PR TITLE
Vips dzsave zip compression support

### DIFF
--- a/libvips/foreign/dzsave.c
+++ b/libvips/foreign/dzsave.c
@@ -147,6 +147,14 @@
 #include <vips/vips.h>
 #include <vips/internal.h>
 
+#define VIPS_ZIP_STORE 0
+#define VIPS_ZIP_DEFLATE 8
+#define VIPS_ZIP_DEFAULT_COMPRESSION -1
+
+/* libgsf before 1.14.31 did not support deflate-level.
+ */
+#define vips_gsf_has_zip64 vips_gsf_has_deflate_level
+
 /* Track this during property save.
  */
 typedef struct _WriteInfo { 
@@ -326,6 +334,10 @@ typedef struct _VipsGsfDirectory {
 	 */
         GsfOutput *container;
 
+	/* Set deflate compression level for zip container.
+	 */
+	gint compression_level;
+
 } VipsGsfDirectory; 
 
 /* Close all dirs, non-NULL on error.
@@ -383,7 +395,7 @@ vips_gsf_tree_free( VipsGsfDirectory *tree )
 /* Make a new tree root.
  */
 static VipsGsfDirectory *
-vips_gsf_tree_new( GsfOutput *out, gboolean is_zip )
+vips_gsf_tree_new( GsfOutput *out, gboolean is_zip, gint compression_level )
 {
 	VipsGsfDirectory *tree = g_new( VipsGsfDirectory, 1 );
 
@@ -393,6 +405,7 @@ vips_gsf_tree_new( GsfOutput *out, gboolean is_zip )
 	tree->out = out;
 	tree->is_zip = is_zip;
 	tree->container = NULL;
+	tree->compression_level = compression_level;
 
 	return( tree ); 
 }
@@ -430,12 +443,13 @@ vips_gsf_dir_new( VipsGsfDirectory *parent, const char *name )
 	dir->children = NULL;
 	dir->is_zip = parent->is_zip;
 	dir->container = NULL;
+	dir->compression_level = parent->compression_level;
 
 	if( dir->is_zip ) 
 		dir->out = gsf_outfile_new_child_full( 
 			(GsfOutfile *) parent->out, 
 			name, TRUE,
-			"compression-level", 0, 
+			"compression-level", VIPS_ZIP_STORE,
 			NULL );
 	else
 		dir->out = gsf_outfile_new_child( 
@@ -475,10 +489,25 @@ vips_gsf_path( VipsGsfDirectory *tree, const char *name, ... )
 	va_end( ap );
 
 	if( dir->is_zip )
-		obj = gsf_outfile_new_child_full( (GsfOutfile *) dir->out,
-			name, FALSE,
-			"compression-level", 0,
-			NULL );
+		if( dir->compression_level == 0 )
+			obj = gsf_outfile_new_child_full(
+				(GsfOutfile *) dir->out,
+				name, FALSE,
+				"compression-level", VIPS_ZIP_STORE,
+				NULL );
+		else if( dir->compression_level == VIPS_ZIP_DEFAULT_COMPRESSION )
+			obj = gsf_outfile_new_child_full(
+				(GsfOutfile *) dir->out,
+				name, FALSE,
+				"compression-level", VIPS_ZIP_DEFLATE,
+				NULL );
+		else
+			obj = gsf_outfile_new_child_full(
+				(GsfOutfile *) dir->out,
+				name, FALSE,
+				"compression-level", VIPS_ZIP_DEFLATE,
+				"deflate-level", dir->compression_level,
+				NULL );
 	else
 		obj = gsf_outfile_new_child( (GsfOutfile *) dir->out,
 			name, FALSE ); 
@@ -560,6 +589,7 @@ struct _VipsForeignSaveDz {
 	gboolean properties;
 	VipsAngle angle;
 	VipsForeignDzContainer container; 
+	int compression;
 
 	Layer *layer;			/* x2 shrink pyr layer */
 
@@ -1827,7 +1857,7 @@ vips_foreign_save_dz_build( VipsObject *object )
 				return( -1 );
 			}
 		
-			dz->tree = vips_gsf_tree_new( out, FALSE );
+			dz->tree = vips_gsf_tree_new( out, FALSE, 0 );
 		}
 		else { 
 			GsfOutput *out;
@@ -1842,7 +1872,7 @@ vips_foreign_save_dz_build( VipsObject *object )
 				return( -1 );
 			}
 		
-			dz->tree = vips_gsf_tree_new( out, FALSE );
+			dz->tree = vips_gsf_tree_new( out, FALSE, 0 );
 		}
 		break;
 
@@ -1878,10 +1908,16 @@ vips_foreign_save_dz_build( VipsObject *object )
 		 */
 		out2 = gsf_outfile_new_child_full( (GsfOutfile *) zip, 
 			dz->basename, TRUE,
-			"compression-level", 0, 
+			"compression-level", VIPS_ZIP_STORE, 
 			NULL );
 
-		dz->tree = vips_gsf_tree_new( out2, TRUE );
+		if( dz->compression > 0 && !vips_gsf_has_deflate_level() ) {
+			vips_warn( "VipsDzSave", 
+				"%s",
+				_( "libgsf too old, using default compression" ) );
+			dz->compression = VIPS_ZIP_DEFAULT_COMPRESSION;
+		}
+		dz->tree = vips_gsf_tree_new( out2, TRUE, dz->compression );
 
 		/* Note the thing that will need closing up on exit.
 		 */
@@ -2072,6 +2108,13 @@ vips_foreign_save_dz_class_init( VipsForeignSaveDzClass *class )
 		G_STRUCT_OFFSET( VipsForeignSaveDz, properties ),
 		FALSE );
 
+	VIPS_ARG_INT( class, "compression", 17, 
+		_( "Compression" ), 
+		_( "ZIP deflate compression level" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignSaveDz, compression ),
+		-1, 9, 0 );
+
 	/* How annoying. We stupidly had these in earlier versions.
 	 */
 
@@ -2116,6 +2159,7 @@ vips_foreign_save_dz_init( VipsForeignSaveDz *dz )
 	dz->depth = VIPS_FOREIGN_DZ_DEPTH_ONEPIXEL; 
 	dz->angle = VIPS_ANGLE_D0; 
 	dz->container = VIPS_FOREIGN_DZ_CONTAINER_FS; 
+	dz->compression = 0;
 }
 
 #endif /*HAVE_GSF*/
@@ -2138,6 +2182,7 @@ vips_foreign_save_dz_init( VipsForeignSaveDz *dz )
  * * @angle: rotate the image by this much
  * * @container: set container type
  * * @properties: write a properties file
+ * * @compression: zip deflate compression level
  *
  * Save an image as a set of tiles at various resolutions. By default dzsave
  * uses DeepZoom layout -- use @layout to pick other conventions.
@@ -2167,6 +2212,10 @@ vips_foreign_save_dz_init( VipsForeignSaveDz *dz )
  * metadata attached to @in in an obvious manner. It can be useful for viewing
  * programs which wish to use fields from source files loaded via
  * vips_openslideload(). 
+ *
+ * If @container is set to `zip`, you can set a compression level from -1
+ * (use zlib default), 0 (store, compression disabled) to 9 (max compression).
+ * If no value is given, the default is to store files without compression.
  *
  * See also: vips_tiffsave().
  *

--- a/libvips/foreign/dzsave.c
+++ b/libvips/foreign/dzsave.c
@@ -319,7 +319,7 @@ typedef struct _VipsGsfDirectory {
 
 	/* If we need to turn off compression for this container.
 	 */
-	gboolean no_compression;
+	gboolean is_zip;
 
 	/* The root node holds the enclosing zip file or FS root ... finish
 	 * this on cleanup.
@@ -383,7 +383,7 @@ vips_gsf_tree_free( VipsGsfDirectory *tree )
 /* Make a new tree root.
  */
 static VipsGsfDirectory *
-vips_gsf_tree_new( GsfOutput *out, gboolean no_compression )
+vips_gsf_tree_new( GsfOutput *out, gboolean is_zip )
 {
 	VipsGsfDirectory *tree = g_new( VipsGsfDirectory, 1 );
 
@@ -391,7 +391,7 @@ vips_gsf_tree_new( GsfOutput *out, gboolean no_compression )
 	tree->name = NULL;
 	tree->children = NULL;
 	tree->out = out;
-	tree->no_compression = no_compression;
+	tree->is_zip = is_zip;
 	tree->container = NULL;
 
 	return( tree ); 
@@ -428,10 +428,10 @@ vips_gsf_dir_new( VipsGsfDirectory *parent, const char *name )
 	dir->parent = parent;
 	dir->name = g_strdup( name );
 	dir->children = NULL;
-	dir->no_compression = parent->no_compression;
+	dir->is_zip = parent->is_zip;
 	dir->container = NULL;
 
-	if( dir->no_compression ) 
+	if( dir->is_zip ) 
 		dir->out = gsf_outfile_new_child_full( 
 			(GsfOutfile *) parent->out, 
 			name, TRUE,
@@ -474,7 +474,7 @@ vips_gsf_path( VipsGsfDirectory *tree, const char *name, ... )
 			dir = vips_gsf_dir_new( dir, dir_name );
 	va_end( ap );
 
-	if( dir->no_compression )
+	if( dir->is_zip )
 		obj = gsf_outfile_new_child_full( (GsfOutfile *) dir->out,
 			name, FALSE,
 			"compression-level", 0,

--- a/test/test_foreign.py
+++ b/test/test_foreign.py
@@ -609,7 +609,13 @@ class TestForeign(unittest.TestCase):
         self.colour.dzsave("test.zip")
         self.assertFalse(os.path.exists("test_files"))
         self.assertFalse(os.path.exists("test.dzi"))
+
+        # test compressed zip output
+        self.colour.dzsave("test_compressed.zip", compression = -1)
+        self.assertLess(os.path.getsize("test_compressed.zip"),
+                        os.path.getsize("test.zip"))
         os.unlink("test.zip")
+        os.unlink("test_compressed.zip")
 
         # test suffix 
         self.colour.dzsave("test", suffix = ".png")


### PR DESCRIPTION
This adds support for enabling ZIP compression and setting the deflate compression level when using dzsave with the zip container type.

The general consensus is, that there's no use in compressing already compressed image types like JPEG. However this is not true if the file itself is not well compressible by JPEG, as is the case with (mostly) blank tiles.

In my tests I am saving between 15-25% on the total ZIP size depending on the JPEG compression level used and how many solid areas the source image contains. Also see my comments in #352.

Example using the [Blue Marble Next Generation](http://visibleearth.nasa.gov/view.php?id=73909) image, which contains some nearly solid areas like oceans and Antarctica:

```sh
for i in `seq 0 9`; do
  echo -n "$i "
  time vips dzsave world-86400x43200.tif world-86400x43200-dz900z${i}.zip \
    --suffix '.jpg[Q=75,quant_table=3]' --layout dz --strip --background 0 \
    --tile-size 900 --depth onetile --compression $i
done

0 vips dzsave world-86400x43200.tif   dz     107,88s user 33,57s system 199% cpu 1:10,75 total
1 vips dzsave world-86400x43200.tif   dz     114,88s user 37,65s system 192% cpu 1:19,16 total
2 vips dzsave world-86400x43200.tif   dz     111,73s user 36,37s system 189% cpu 1:18,02 total
3 vips dzsave world-86400x43200.tif   dz     105,16s user 34,60s system 190% cpu 1:13,32 total
4 vips dzsave world-86400x43200.tif   dz     104,94s user 34,05s system 188% cpu 1:13,74 total
5 vips dzsave world-86400x43200.tif   dz     105,67s user 34,55s system 187% cpu 1:14,95 total
6 vips dzsave world-86400x43200.tif   dz     104,77s user 34,38s system 188% cpu 1:13,87 total
7 vips dzsave world-86400x43200.tif   dz     106,27s user 34,49s system 187% cpu 1:15,13 total
8 vips dzsave world-86400x43200.tif   dz     105,94s user 34,56s system 186% cpu 1:15,39 total
9 vips dzsave world-86400x43200.tif   dz     105,75s user 34,07s system 187% cpu 1:14,76 total

ls -hal world-86400x43200-dz900z?.zip
-rw-r--r--  1 felix  staff   237M  3 Jun 23:33 world-86400x43200-dz900z0.zip
-rw-r--r--  1 felix  staff   205M  3 Jun 23:34 world-86400x43200-dz900z1.zip
-rw-r--r--  1 felix  staff   204M  3 Jun 23:36 world-86400x43200-dz900z2.zip
-rw-r--r--  1 felix  staff   204M  3 Jun 23:37 world-86400x43200-dz900z3.zip
-rw-r--r--  1 felix  staff   203M  3 Jun 23:38 world-86400x43200-dz900z4.zip
-rw-r--r--  1 felix  staff   203M  3 Jun 23:39 world-86400x43200-dz900z5.zip
-rw-r--r--  1 felix  staff   202M  3 Jun 23:40 world-86400x43200-dz900z6.zip
-rw-r--r--  1 felix  staff   202M  3 Jun 23:42 world-86400x43200-dz900z7.zip
-rw-r--r--  1 felix  staff   202M  3 Jun 23:43 world-86400x43200-dz900z8.zip
-rw-r--r--  1 felix  staff   202M  3 Jun 23:44 world-86400x43200-dz900z9.zip
```

As we can see there is not much to gain from raising compression level above deflate level 1, but there is also nearly no overhead for enabling compression at any level.

I also tested with my normal images which are only 3000x3000 to 5400x5400 but contain a lot of solid areas and I'm seeing around 20% savings.

**ToDo:**

- [x] Add python test that checks compression is working