### PR TITLE
Re-enable Travis CI builds on all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,3 @@
-branches:
-  only:
-    - master
-    - stable
-
 language: cpp
 
 before_script:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # libvips : an image processing library
 
-[![Build Status](https://secure.travis-ci.org/jcupitt/libvips.png)](http://travis-ci.org/jcupitt/libvips)
+[![Build Status](https://travis-ci.org/jcupitt/libvips.svg?branch=master)](https://travis-ci.org/jcupitt/libvips)
 [![Coverity Status](https://scan.coverity.com/projects/6503/badge.svg)](https://scan.coverity.com/projects/jcupitt-libvips)
 
 libvips is a 2D image processing library. Compared to


### PR DESCRIPTION
This re-enables travis ci to trigger for all branches, so it can be used to check the build on forks without having to modify `.travis.yml`.

The reason given for the change was the failing build badge, so this changes the build badge to monitor the master branch instead.