### PR TITLE
Round WebP shrink-on-load dimensions

### DIFF
--- a/libvips/foreign/webp2vips.c
+++ b/libvips/foreign/webp2vips.c
@@ -186,8 +186,8 @@ read_new( const char *filename, const void *data, size_t length, int shrink )
 
 	read->config.options.use_threads = 1;
 
-	read->width = read->config.input.width / read->shrink;
-	read->height = read->config.input.height / read->shrink;
+	read->width = VIPS_RINT( (float) read->config.input.width / read->shrink );
+	read->height = VIPS_RINT( (float) read->config.input.height / read->shrink );
 
 	if( read->width == 0 ||
 		read->height == 0 ) {


### PR DESCRIPTION
Hi John, this was discovered by @asilvas in lovell/sharp#508

(Casting to a float should provide enough accuracy here as WebP uses only 14-bits for dimensions.)