### PR TITLE
cplusplus - move assignment operators outside class, enables DLL exporting

### DIFF
--- a/cplusplus/VImage.cpp
+++ b/cplusplus/VImage.cpp
@@ -770,21 +770,21 @@ operator+( VImage a, std::vector<double> b )
 }
 
 VImage & 
-VImage::operator+=( const VImage b )
+operator+=( VImage a, const VImage b )
 {
-	return( *this = *this + b ); 
+	return( a = a + b ); 
 }
 
 VImage & 
-VImage::operator+=( const double b )
+operator+=( VImage a, const double b )
 {
-	return( *this = *this + b ); 
+	return( a = a + b ); 
 }
 
 VImage & 
-VImage::operator+=( std::vector<double> b )
+operator+=( VImage a, std::vector<double> b )
 {
-	return( *this = *this + b ); 
+	return( a = a + b ); 
 }
 
 VImage 
@@ -818,21 +818,21 @@ operator-( VImage a, std::vector<double> b )
 }
 
 VImage & 
-VImage::operator-=( const VImage b )
+operator-=( VImage a, const VImage b )
 {
-	return( *this = *this - b ); 
+	return( a = a - b ); 
 }
 
 VImage & 
-VImage::operator-=( const double b )
+operator-=( VImage a, const double b )
 {
-	return( *this = *this - b ); 
+	return( a = a - b ); 
 }
 
 VImage & 
-VImage::operator-=( std::vector<double> b )
+operator-=( VImage a, std::vector<double> b )
 {
-	return( *this = *this - b ); 
+	return( a = a - b ); 
 }
 
 VImage 
@@ -872,21 +872,21 @@ operator*( VImage a, std::vector<double> b )
 }
 
 VImage & 
-VImage::operator*=( const VImage b )
+operator*=( VImage a, const VImage b )
 {
-	return( *this = *this * b ); 
+	return( a = a * b ); 
 }
 
 VImage & 
-VImage::operator*=( const double b )
+operator*=( VImage a, const double b )
 {
-	return( *this = *this * b ); 
+	return( a = a * b ); 
 }
 
 VImage & 
-VImage::operator*=( std::vector<double> b )
+operator*=( VImage a, std::vector<double> b )
 {
-	return( *this = *this * b ); 
+	return( a = a * b ); 
 }
 
 VImage 
@@ -920,21 +920,21 @@ operator/( VImage a, std::vector<double> b )
 }
 
 VImage & 
-VImage::operator/=( const VImage b )
+operator/=( VImage a, const VImage b )
 {
-	return( *this = *this / b ); 
+	return( a = a / b ); 
 }
 
 VImage & 
-VImage::operator/=( const double b )
+operator/=( VImage a, const double b )
 {
-	return( *this = *this / b ); 
+	return( a = a / b ); 
 }
 
 VImage & 
-VImage::operator/=( std::vector<double> b )
+operator/=( VImage a, std::vector<double> b )
 {
-	return( *this = *this / b ); 
+	return( a = a / b ); 
 }
 
 VImage 
@@ -956,21 +956,21 @@ operator%( VImage a, std::vector<double> b )
 }
 
 VImage & 
-VImage::operator%=( const VImage b )
+operator%=( VImage a, const VImage b )
 {
-	return( *this = *this % b ); 
+	return( a = a % b ); 
 }
 
 VImage & 
-VImage::operator%=( const double b )
+operator%=( VImage a, const double b )
 {
-	return( *this = *this % b ); 
+	return( a = a % b ); 
 }
 
 VImage & 
-VImage::operator%=( std::vector<double> b )
+operator%=( VImage a, std::vector<double> b )
 {
-	return( *this = *this % b ); 
+	return( a = a % b ); 
 }
 
 VImage 
@@ -1210,21 +1210,21 @@ operator&( VImage a, std::vector<double> b )
 }
 
 VImage & 
-VImage::operator&=( const VImage b )
+operator&=( VImage a, const VImage b )
 {
-	return( *this = *this & b ); 
+	return( a = a & b ); 
 }
 
 VImage & 
-VImage::operator&=( const double b )
+operator&=( VImage a, const double b )
 {
-	return( *this = *this & b ); 
+	return( a = a & b ); 
 }
 
 VImage & 
-VImage::operator&=( std::vector<double> b )
+operator&=( VImage a, std::vector<double> b )
 {
-	return( *this = *this & b ); 
+	return( a = a & b ); 
 }
 
 VImage 
@@ -1260,21 +1260,21 @@ operator|( VImage a, std::vector<double> b )
 }
 
 VImage & 
-VImage::operator|=( const VImage b )
+operator|=( VImage a, const VImage b )
 {
-	return( *this = *this | b ); 
+	return( a = a | b ); 
 }
 
 VImage & 
-VImage::operator|=( const double b )
+operator|=( VImage a, const double b )
 {
-	return( *this = *this | b ); 
+	return( a = a | b ); 
 }
 
 VImage & 
-VImage::operator|=( std::vector<double> b )
+operator|=( VImage a, std::vector<double> b )
 {
-	return( *this = *this | b ); 
+	return( a = a | b ); 
 }
 
 VImage 
@@ -1310,21 +1310,21 @@ operator^( VImage a, std::vector<double> b )
 }
 
 VImage & 
-VImage::operator^=( const VImage b )
+operator^=( VImage a, const VImage b )
 {
-	return( *this = *this ^ b ); 
+	return( a = a ^ b ); 
 }
 
 VImage & 
-VImage::operator^=( const double b )
+operator^=( VImage a, const double b )
 {
-	return( *this = *this ^ b ); 
+	return( a = a ^ b ); 
 }
 
 VImage & 
-VImage::operator^=( std::vector<double> b )
+operator^=( VImage a, std::vector<double> b )
 {
-	return( *this = *this ^ b ); 
+	return( a = a ^ b ); 
 }
 
 VImage 
@@ -1347,21 +1347,21 @@ operator<<( VImage a, std::vector<double> b )
 }
 
 VImage & 
-VImage::operator<<=( const VImage b )
+operator<<=( VImage a, const VImage b )
 {
-	return( *this = *this << b ); 
+	return( a = a << b ); 
 }
 
 VImage & 
-VImage::operator<<=( const double b )
+operator<<=( VImage a, const double b )
 {
-	return( *this = *this << b ); 
+	return( a = a << b ); 
 }
 
 VImage & 
-VImage::operator<<=( std::vector<double> b )
+operator<<=( VImage a, std::vector<double> b )
 {
-	return( *this = *this << b ); 
+	return( a = a << b ); 
 }
 
 VImage 
@@ -1384,21 +1384,21 @@ operator>>( VImage a, std::vector<double> b )
 }
 
 VImage & 
-VImage::operator>>=( const VImage b )
+operator>>=( VImage a, const VImage b )
 {
-	return( *this = *this << b ); 
+	return( a = a << b ); 
 }
 
 VImage & 
-VImage::operator>>=( const double b )
+operator>>=( VImage a, const double b )
 {
-	return( *this = *this << b ); 
+	return( a = a << b ); 
 }
 
 VImage & 
-VImage::operator>>=( std::vector<double> b )
+operator>>=( VImage a, std::vector<double> b )
 {
-	return( *this = *this << b ); 
+	return( a = a << b ); 
 }
 
 VIPS_NAMESPACE_END

--- a/cplusplus/include/vips/VImage8.h
+++ b/cplusplus/include/vips/VImage8.h
@@ -775,137 +775,137 @@ public:
 
 	std::vector<double> operator()( int x, int y );
 
-	friend VImage VIPS_CPLUSPLUS_API operator+( VImage a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator+( double a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator+( VImage a, double b );
-	friend VImage VIPS_CPLUSPLUS_API operator+( std::vector<double> a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator+( VImage a, std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage operator+( VImage a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator+( double a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator+( VImage a, double b );
+	friend VIPS_CPLUSPLUS_API VImage operator+( std::vector<double> a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator+( VImage a, std::vector<double> b );
 
-	VImage & VIPS_CPLUSPLUS_API operator+=( const VImage b );
-	VImage & VIPS_CPLUSPLUS_API operator+=( const double b );
-	VImage & VIPS_CPLUSPLUS_API operator+=( const std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage & operator+=( VImage a, const VImage b );
+	friend VIPS_CPLUSPLUS_API VImage & operator+=( VImage a, const double b );
+	friend VIPS_CPLUSPLUS_API VImage & operator+=( VImage a, const std::vector<double> b );
 
-	friend VImage VIPS_CPLUSPLUS_API operator-( VImage a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator-( double a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator-( VImage a, double b );
-	friend VImage VIPS_CPLUSPLUS_API operator-( std::vector<double> a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator-( VImage a, std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage operator-( VImage a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator-( double a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator-( VImage a, double b );
+	friend VIPS_CPLUSPLUS_API VImage operator-( std::vector<double> a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator-( VImage a, std::vector<double> b );
 
-	VImage & VIPS_CPLUSPLUS_API operator-=( const VImage b );
-	VImage & VIPS_CPLUSPLUS_API operator-=( const double b );
-	VImage & VIPS_CPLUSPLUS_API operator-=( const std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage & operator-=( VImage a, const VImage b );
+	friend VIPS_CPLUSPLUS_API VImage & operator-=( VImage a, const double b );
+	friend VIPS_CPLUSPLUS_API VImage & operator-=( VImage a, const std::vector<double> b );
 
-	friend VImage VIPS_CPLUSPLUS_API operator-( VImage a );
+	friend VIPS_CPLUSPLUS_API VImage operator-( VImage a );
 
-	friend VImage VIPS_CPLUSPLUS_API operator*( VImage a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator*( double a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator*( VImage a, double b );
-	friend VImage VIPS_CPLUSPLUS_API operator*( std::vector<double> a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator*( VImage a, std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage operator*( VImage a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator*( double a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator*( VImage a, double b );
+	friend VIPS_CPLUSPLUS_API VImage operator*( std::vector<double> a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator*( VImage a, std::vector<double> b );
 
-	VImage & VIPS_CPLUSPLUS_API operator*=( const VImage b );
-	VImage & VIPS_CPLUSPLUS_API operator*=( const double b );
-	VImage & VIPS_CPLUSPLUS_API operator*=( const std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage & operator*=( VImage a, const VImage b );
+	friend VIPS_CPLUSPLUS_API VImage & operator*=( VImage a, const double b );
+	friend VIPS_CPLUSPLUS_API VImage & operator*=( VImage a, const std::vector<double> b );
 
-	friend VImage VIPS_CPLUSPLUS_API operator/( VImage a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator/( double a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator/( VImage a, double b );
-	friend VImage VIPS_CPLUSPLUS_API operator/( std::vector<double> a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator/( VImage a, std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage operator/( VImage a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator/( double a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator/( VImage a, double b );
+	friend VIPS_CPLUSPLUS_API VImage operator/( std::vector<double> a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator/( VImage a, std::vector<double> b );
 
-	VImage & VIPS_CPLUSPLUS_API operator/=( const VImage b );
-	VImage & VIPS_CPLUSPLUS_API operator/=( const double b );
-	VImage & VIPS_CPLUSPLUS_API operator/=( const std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage & operator/=( VImage a, const VImage b );
+	friend VIPS_CPLUSPLUS_API VImage & operator/=( VImage a, const double b );
+	friend VIPS_CPLUSPLUS_API VImage & operator/=( VImage a, const std::vector<double> b );
 
-	friend VImage VIPS_CPLUSPLUS_API operator%( VImage a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator%( VImage a, double b );
-	friend VImage VIPS_CPLUSPLUS_API operator%( VImage a, std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage operator%( VImage a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator%( VImage a, double b );
+	friend VIPS_CPLUSPLUS_API VImage operator%( VImage a, std::vector<double> b );
 
-	VImage & VIPS_CPLUSPLUS_API operator%=( const VImage b );
-	VImage & VIPS_CPLUSPLUS_API operator%=( const double b );
-	VImage & VIPS_CPLUSPLUS_API operator%=( const std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage & operator%=( VImage a, const VImage b );
+	friend VIPS_CPLUSPLUS_API VImage & operator%=( VImage a, const double b );
+	friend VIPS_CPLUSPLUS_API VImage & operator%=( VImage a, const std::vector<double> b );
 
-	friend VImage VIPS_CPLUSPLUS_API operator<( VImage a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator<( double a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator<( VImage a, double b );
-	friend VImage VIPS_CPLUSPLUS_API operator<( std::vector<double> a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator<( VImage a, std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage operator<( VImage a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator<( double a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator<( VImage a, double b );
+	friend VIPS_CPLUSPLUS_API VImage operator<( std::vector<double> a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator<( VImage a, std::vector<double> b );
 
-	friend VImage VIPS_CPLUSPLUS_API operator<=( VImage a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator<=( double a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator<=( VImage a, double b );
-	friend VImage VIPS_CPLUSPLUS_API operator<=( std::vector<double> a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator<=( VImage a, std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage operator<=( VImage a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator<=( double a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator<=( VImage a, double b );
+	friend VIPS_CPLUSPLUS_API VImage operator<=( std::vector<double> a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator<=( VImage a, std::vector<double> b );
 
-	friend VImage VIPS_CPLUSPLUS_API operator>( VImage a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator>( double a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator>( VImage a, double b );
-	friend VImage VIPS_CPLUSPLUS_API operator>( std::vector<double> a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator>( VImage a, std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage operator>( VImage a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator>( double a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator>( VImage a, double b );
+	friend VIPS_CPLUSPLUS_API VImage operator>( std::vector<double> a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator>( VImage a, std::vector<double> b );
 
-	friend VImage VIPS_CPLUSPLUS_API operator>=( VImage a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator>=( double a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator>=( VImage a, double b );
-	friend VImage VIPS_CPLUSPLUS_API operator>=( std::vector<double> a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator>=( VImage a, std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage operator>=( VImage a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator>=( double a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator>=( VImage a, double b );
+	friend VIPS_CPLUSPLUS_API VImage operator>=( std::vector<double> a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator>=( VImage a, std::vector<double> b );
 
-	friend VImage VIPS_CPLUSPLUS_API operator==( VImage a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator==( double a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator==( VImage a, double b );
-	friend VImage VIPS_CPLUSPLUS_API operator==( std::vector<double> a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator==( VImage a, std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage operator==( VImage a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator==( double a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator==( VImage a, double b );
+	friend VIPS_CPLUSPLUS_API VImage operator==( std::vector<double> a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator==( VImage a, std::vector<double> b );
 
-	friend VImage VIPS_CPLUSPLUS_API operator!=( VImage a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator!=( double a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator!=( VImage a, double b );
-	friend VImage VIPS_CPLUSPLUS_API operator!=( std::vector<double> a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator!=( VImage a, std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage operator!=( VImage a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator!=( double a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator!=( VImage a, double b );
+	friend VIPS_CPLUSPLUS_API VImage operator!=( std::vector<double> a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator!=( VImage a, std::vector<double> b );
 
-	friend VImage VIPS_CPLUSPLUS_API operator&( VImage a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator&( double a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator&( VImage a, double b );
-	friend VImage VIPS_CPLUSPLUS_API operator&( std::vector<double> a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator&( VImage a, std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage operator&( VImage a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator&( double a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator&( VImage a, double b );
+	friend VIPS_CPLUSPLUS_API VImage operator&( std::vector<double> a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator&( VImage a, std::vector<double> b );
 
-	VImage & VIPS_CPLUSPLUS_API operator&=( const VImage b );
-	VImage & VIPS_CPLUSPLUS_API operator&=( const double b );
-	VImage & VIPS_CPLUSPLUS_API operator&=( const std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage & operator&=( VImage a, const VImage b );
+	friend VIPS_CPLUSPLUS_API VImage & operator&=( VImage a, const double b );
+	friend VIPS_CPLUSPLUS_API VImage & operator&=( VImage a, const std::vector<double> b );
 
-	friend VImage VIPS_CPLUSPLUS_API operator|( VImage a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator|( double a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator|( VImage a, double b );
-	friend VImage VIPS_CPLUSPLUS_API operator|( std::vector<double> a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator|( VImage a, std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage operator|( VImage a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator|( double a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator|( VImage a, double b );
+	friend VIPS_CPLUSPLUS_API VImage operator|( std::vector<double> a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator|( VImage a, std::vector<double> b );
 
-	VImage & VIPS_CPLUSPLUS_API operator|=( const VImage b );
-	VImage & VIPS_CPLUSPLUS_API operator|=( const double b );
-	VImage & VIPS_CPLUSPLUS_API operator|=( const std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage & operator|=( VImage a, const VImage b );
+	friend VIPS_CPLUSPLUS_API VImage & operator|=( VImage a, const double b );
+	friend VIPS_CPLUSPLUS_API VImage & operator|=( VImage a, const std::vector<double> b );
 
-	friend VImage VIPS_CPLUSPLUS_API operator^( VImage a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator^( double a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator^( VImage a, double b );
-	friend VImage VIPS_CPLUSPLUS_API operator^( std::vector<double> a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator^( VImage a, std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage operator^( VImage a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator^( double a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator^( VImage a, double b );
+	friend VIPS_CPLUSPLUS_API VImage operator^( std::vector<double> a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator^( VImage a, std::vector<double> b );
 
-	VImage & VIPS_CPLUSPLUS_API operator^=( const VImage b );
-	VImage & VIPS_CPLUSPLUS_API operator^=( const double b );
-	VImage & VIPS_CPLUSPLUS_API operator^=( const std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage & operator^=( VImage a, const VImage b );
+	friend VIPS_CPLUSPLUS_API VImage & operator^=( VImage a, const double b );
+	friend VIPS_CPLUSPLUS_API VImage & operator^=( VImage a, const std::vector<double> b );
 
-	friend VImage VIPS_CPLUSPLUS_API operator<<( VImage a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator<<( VImage a, double b );
-	friend VImage VIPS_CPLUSPLUS_API operator<<( VImage a, std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage operator<<( VImage a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator<<( VImage a, double b );
+	friend VIPS_CPLUSPLUS_API VImage operator<<( VImage a, std::vector<double> b );
 
-	VImage & VIPS_CPLUSPLUS_API operator<<=( const VImage b );
-	VImage & VIPS_CPLUSPLUS_API operator<<=( const double b );
-	VImage & VIPS_CPLUSPLUS_API operator<<=( const std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage & operator<<=( VImage a, const VImage b );
+	friend VIPS_CPLUSPLUS_API VImage & operator<<=( VImage a, const double b );
+	friend VIPS_CPLUSPLUS_API VImage & operator<<=( VImage a, const std::vector<double> b );
 
-	friend VImage VIPS_CPLUSPLUS_API operator>>( VImage a, VImage b );
-	friend VImage VIPS_CPLUSPLUS_API operator>>( VImage a, double b );
-	friend VImage VIPS_CPLUSPLUS_API operator>>( VImage a, std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage operator>>( VImage a, VImage b );
+	friend VIPS_CPLUSPLUS_API VImage operator>>( VImage a, double b );
+	friend VIPS_CPLUSPLUS_API VImage operator>>( VImage a, std::vector<double> b );
 
-	VImage & VIPS_CPLUSPLUS_API operator>>=( const VImage b );
-	VImage & VIPS_CPLUSPLUS_API operator>>=( const double b );
-	VImage & VIPS_CPLUSPLUS_API operator>>=( const std::vector<double> b );
+	friend VIPS_CPLUSPLUS_API VImage & operator>>=( VImage a, const VImage b );
+	friend VIPS_CPLUSPLUS_API VImage & operator>>=( VImage a, const double b );
+	friend VIPS_CPLUSPLUS_API VImage & operator>>=( VImage a, const std::vector<double> b );
 
 };
 


### PR DESCRIPTION
Hi John, this PR updates the assignment operator overloads introduced in 28efdf1 to work with MSVC by moving them "outside" the class and therefore enable DLL exporting.

Without this, MSVC generates the following rather cryptic error:
```
error C2487: '+=': member of dll interface class may not be declared with dll interface
```

There's also a bit of an MSVC annoyance in that when returning by reference, the __declspec bit has to go before the type, so what I ended up doing was ensuring a consistent modifier order across all exported functions, which looks a bit neater.