### PR TITLE
Increase SVG buffer check length by 50 bytes

### DIFF
--- a/libvips/foreign/svgload.c
+++ b/libvips/foreign/svgload.c
@@ -482,7 +482,7 @@ vips_foreign_load_svg_is_a_buffer( const void *buf, size_t len )
 		if( !isascii( str[i] ) )
 			return( FALSE );
 
-	for( i = 0; i < 200 && i < len - 5; i++ ) 
+	for( i = 0; i < 250 && i < len - 5; i++ )
 		if( g_ascii_strncasecmp( str + i, "<svg", 4 ) == 0 )
 			return( TRUE );
 


### PR DESCRIPTION
Hi John, was the 200 value an otherwise arbitrary limit? Increasing it to 250 will provide support for "real world" SVG files such as the following unnecessary preamble exported by Adobe Illustrator:

```svg
<?xml version="1.0" encoding="utf-8"?>
<!-- Generator: Adobe Illustrator 18.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
<svg ...
```
https://raw.githubusercontent.com/sandstorm-io/sandstorm/master/icons/key.svg
