### PR TITLE
Silence 'missing sentinel' warnings in GCC v6+

### DIFF
--- a/libvips/resample/reduceh.cpp
+++ b/libvips/resample/reduceh.cpp
@@ -506,12 +506,12 @@ vips_reduceh_build( VipsObject *object )
 		reduceh->n_point / 2 - 1, 0, 
 		width, in->Ysize,
 		"extend", VIPS_EXTEND_COPY,
-		NULL ) )
+		(void *) NULL ) )
 		return( -1 );
 	in = t[1];
 
 	if( vips_image_pipelinev( resample->out, 
-		VIPS_DEMAND_STYLE_THINSTRIP, in, NULL ) )
+		VIPS_DEMAND_STYLE_THINSTRIP, in, (void *) NULL ) )
 		return( -1 );
 
 	/* Size output. We need to always round to nearest, so round(), not

--- a/libvips/resample/reducev.cpp
+++ b/libvips/resample/reducev.cpp
@@ -787,7 +787,7 @@ vips_reducev_raw( VipsReducev *reducev, VipsImage *in, VipsImage **out )
 
 	*out = vips_image_new();
 	if( vips_image_pipelinev( *out, 
-		VIPS_DEMAND_STYLE_FATSTRIP, in, NULL ) )
+		VIPS_DEMAND_STYLE_FATSTRIP, in, (void *) NULL ) )
 		return( -1 );
 
 	/* Size output. We need to always round to nearest, so round(), not
@@ -870,7 +870,7 @@ vips_reducev_build( VipsObject *object )
 		0, reducev->n_point / 2 - 1, 
 		in->Xsize, height, 
 		"extend", VIPS_EXTEND_COPY,
-		NULL ) )
+		(void *) NULL ) )
 		return( -1 );
 	in = t[1];
 
@@ -894,7 +894,7 @@ vips_reducev_build( VipsObject *object )
 		if( vips_sequential( in, &t[3], 
 			"tile_height", 10,
 			// "trace", TRUE,
-			NULL ) )
+			(void *) NULL ) )
 			return( -1 );
 		in = t[3];
 	}


### PR DESCRIPTION
GCC v6+ is starting to warn about the use of `NULL` as a sentinel value in C++ sources (as `NULL` is considered a zero value rather than a null pointer).

```
reduceh.cpp: In function 'int vips_reduceh_build(VipsObject*)':
reduceh.cpp:509:8: warning: missing sentinel in function call [-Wformat=]
   NULL ) )
        ^
reduceh.cpp:514:41: warning: missing sentinel in function call [-Wformat=]
   VIPS_DEMAND_STYLE_THINSTRIP, in, NULL ) )
                                         ^
reducev.cpp:790:40: warning: missing sentinel in function call [-Wformat=]
   VIPS_DEMAND_STYLE_FATSTRIP, in, NULL ) )
                                        ^
reducev.cpp: In function 'int vips_reducev_build(VipsObject*)':
reducev.cpp:873:8: warning: missing sentinel in function call [-Wformat=]
   NULL ) )
        ^
reducev.cpp:897:9: warning: missing sentinel in function call [-Wformat=]
    NULL ) )
         ^
```
