### PR TITLE
Autofit text in the requested dimensions

### DIFF
--- a/libvips/create/text.c
+++ b/libvips/create/text.c
@@ -411,7 +411,7 @@ vips_text_build( VipsObject *object )
 		 * is rendered. We cannot reliably do resizing after rendering
 		 * because we lose the lock, and we need to rely on vips_resize
 		 */
-		if( width > text->width || height > text->height ) {
+		if( !is_font_size_provided && ( width > text->width || height > text->height ) ) {
 			double scale_w = (double)text->width / width;
 			double scale_h = (double)text->height / height;
 			double scale = scale_w > scale_h ? scale_h : scale_w;

--- a/libvips/create/text.c
+++ b/libvips/create/text.c
@@ -54,7 +54,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <stdbool.h>
 
 #include <vips/vips.h>
 
@@ -197,23 +196,24 @@ determine_deviation( int width, int height, PangoRectangle rect ) {
 	return dw ? dw : dh;
 }
 
-static bool
+static gboolean
 search_flist( FontSizeList *flist, int size )
 {
 	FontSizeList *entry = flist;
 	while( entry->next != NULL ) {
 		if( entry->size == size )
-			return true;
+			return TRUE;
 		entry = entry->next;
 	}
-	return false;
+	return FALSE;
 }
 
 static FontSizeList *
 least_deviation_flist( FontSizeList *flist )
 {
 	FontSizeList *entry = flist;
-	// This works for all practical purposes
+	/* This works for all practical purposes
+	 */
 	long smallest = 1999999999;
 	FontSizeList *least;
 	while( entry->next != NULL ) {
@@ -238,7 +238,7 @@ append_to_flist( FontSizeList *flist, FontSizeList *nflist )
 
 static PangoRectangle
 fit_to_bounds( VipsText *text,
-	char *name, int size, PangoRectangle rect, FontSizeList *flist, bool coarse )
+	char *name, int size, PangoRectangle rect, FontSizeList *flist, gboolean coarse )
 {
 	int buf_size = strlen( name ) + digits_in_num( size ) + 2;
 	int deviation;
@@ -250,8 +250,9 @@ fit_to_bounds( VipsText *text,
 	FontSizeList *nflist = (FontSizeList *) malloc( sizeof( FontSizeList ) );
 
 	if( coarse ) {
-		// A factor of X increase in font size causes X^2 increase in the area
-		// occupied by the text
+		/* A factor of X increase in font size causes X^2 increase in the area
+		 * occupied by the text
+		 */
 		size = (int)((double)size * sqrt( (double)allowed_area / font_area ));
 	} else {
 		if( allowed_area > font_area ) {
@@ -276,15 +277,17 @@ fit_to_bounds( VipsText *text,
 	nflist->next = NULL;
 	append_to_flist( flist, nflist );
 
-	// If we have been through this font size before, find the one with the
-	// smallest deviation and then fit in small adjustments
+	/* If we have been through this font size before, find the one with the
+	 * smallest deviation and then fit in small adjustments
+	 */
 	if( search_flist( flist, size ) ) {
 		if( coarse ) {
 			return fit_to_bounds( text, name, size, rect,
-				least_deviation_flist( flist ), false );
+				least_deviation_flist( flist ), FALSE );
 		} else {
-			// We cannot do better than this because we will
-			// cycle through sizes again
+			/* We cannot do better than this because we will
+			 * cycle through sizes again
+			 */
 			return rect;
 		}
 	}
@@ -313,7 +316,7 @@ vips_text_build( VipsObject *object )
 	int deviation = 0;
 	int font_size = 0;
 	char *last;
-	bool is_font_size_provided = true;
+	gboolean is_font_size_provided = TRUE;
 
 	if( VIPS_OBJECT_CLASS( vips_text_parent_class )->build( object ) )
 		return( -1 );
@@ -325,10 +328,12 @@ vips_text_build( VipsObject *object )
 	}
 
 	char *font_name[ strlen( text->font ) + 1 ];
-	// Extract font size from provided argument
+	/* Extract font size from provided argument
+	 */
 	last = strrchr( text->font, ' ' );
 
-	// Happens for a single word font names
+	/* Happens for a single word font names
+	 */
 	if( last != '\0' ) {
 		font_size = atol( last );
 	}
@@ -336,12 +341,13 @@ vips_text_build( VipsObject *object )
 	if( font_size ) {
 		strncat( font_name, text->font, last - text->font );
 	} else {
-		// Font was more than 1 MAX_word. "Fira Code" would have last
-		// pointing to "Code", leading atol to output 0
-		// Fix font_name back to the original in this case
+		/* Font was more than 1 word. "Fira Code" would have last
+		 * pointing to "Code", leading atol to output 0
+		 * Fix font_name back to the original in this case
+		 */
 		strcpy( font_name, text->font );
 		font_size = text->height;
-		is_font_size_provided = false;
+		is_font_size_provided = FALSE;
 	}
 
 	g_mutex_lock( vips_text_lock ); 
@@ -374,10 +380,9 @@ vips_text_build( VipsObject *object )
 			flist->area = PANGO_PIXELS( logical_rect.width ) * PANGO_PIXELS( logical_rect.height );
 			flist->next = NULL;
 
-			logical_rect = fit_to_bounds( text, font_name, font_size, logical_rect, flist, true );
+			logical_rect = fit_to_bounds( text, font_name, font_size, logical_rect, flist, TRUE );
 		}
 
-		// Logical rect does not help us with exact bounds of the text
 		pango_layout_get_extents( text->layout, NULL, &logical_rect );
 	}
 
@@ -395,19 +400,17 @@ vips_text_build( VipsObject *object )
 	width = PANGO_PIXELS( logical_rect.width );
 	height = PANGO_PIXELS( logical_rect.height );
 
-	// Match the layout to fit the exact dimensions requested
-	// We also apply gravity here
-	if( !is_font_size_provided && text->width && text->height ) {
-		left = 0;
-		top = 0;
-		width = PANGO_PIXELS( logical_rect.width );
-		height = PANGO_PIXELS( logical_rect.height );
-		
-		// Since the layout is bigger than the requested dimensions, we
-		// scale the layout font description by the same scale
-		// This seems like the only way to resize the layout before it
-		// is rendered. We cannot reliably do resizing after rendering
-		// because we lose the lock, and we need to rely on vips_resize
+	/* Match the layout to fit the exact dimensions requested
+	 * We also apply gravity here
+	 */
+	if( text->width && text->height ) {
+
+		/* Since the layout is bigger than the requested dimensions, we
+		 * scale the layout font description by the same scale
+		 * This seems like the only way to resize the layout before it
+		 * is rendered. We cannot reliably do resizing after rendering
+		 * because we lose the lock, and we need to rely on vips_resize
+		 */
 		if( width > text->width || height > text->height ) {
 			double scale_w = (double)text->width / width;
 			double scale_h = (double)text->height / height;
@@ -419,54 +422,60 @@ vips_text_build( VipsObject *object )
 			pango_layout_set_font_description( text->layout, temp_fd );
 			pango_font_description_free( temp_fd );
 
-			// Overloading logical_rect as an ink rectangle here to determine the
-			// best gravity
-			// For most cases, gravities with north, south components are completely
-			// useless if we do positioning with logical rect
 			pango_layout_get_extents( text->layout, &logical_rect, NULL );
 
 			width = PANGO_PIXELS( logical_rect.width );
 			height = PANGO_PIXELS( logical_rect.height );
 		}
 
+		int padl = 0;
+		int padt = 0;
+
 		switch( text->gravity ) {
 			case VIPS_GRAVITY_CENTER:
-				left = ( text->width - width ) / 2;
+				padl = ( text->width - width ) / 2;
+				padt = ( text->height - height ) / 2;
 				break;
 			case VIPS_GRAVITY_NORTH:
-				top = ( height - text->height ) / 2;
-				left = ( text->width - width ) / 2;
+				padl = ( text->width - width ) / 2;
+				padt = 0;
 				break;
 			case VIPS_GRAVITY_EAST:
-				left = text->width - width;
+				padl = text->width - width;
+				padt = ( text->height - height ) / 2;
 				break;
 			case VIPS_GRAVITY_SOUTH:
-				top = ( text->height - height ) / 2;
-				left = ( text->width - width ) / 2;
+				padl = ( text->width - width ) / 2;
+				padt = text->height - height;
 				break;
 			case VIPS_GRAVITY_WEST:
+				padl = 0;
+				padt = ( text->height - height ) / 2;
 				break;
 			case VIPS_GRAVITY_NORTH_EAST:
-				top = ( height - text->height ) / 2;
-				left = text->width - width;
+				padl = text->width - width;
+				padt = 0;
 				break;
 			case VIPS_GRAVITY_SOUTH_EAST:
-				top = ( text->height - height ) / 2;
-				left = text->width - width;
+				padl = text->width - width;
+				padt = text->height - height;
 				break;
 			case VIPS_GRAVITY_SOUTH_WEST:
-				top = ( text->height - height ) / 2;
+				padl = 0;
+				padt = text->height - height;
 				break;
 			case VIPS_GRAVITY_NORTH_WEST:
-				top = ( height - text->height ) / 2;
+				padl = 0;
+				padt = 0;
 				break;
 			default:
 				break;
 		}
-		left = -1 * left;
-		top = -1 * top;
-		width = text->width;
-		height = text->height;
+
+		left = left - ( width > text->width ? 0 : padl ) + PANGO_PIXELS( logical_rect.x );
+		top = top - ( height > text->height ? 0 : padt ) + PANGO_PIXELS( logical_rect.y );
+		width = text->width > width ? text->width : width;
+		height = text->height > height ? text->height : height;
 	}
 
 	/* Can happen for "", for example.

--- a/libvips/include/vips/create.h
+++ b/libvips/include/vips/create.h
@@ -47,7 +47,8 @@ typedef enum {
 	VIPS_GRAVITY_NORTH_EAST,
 	VIPS_GRAVITY_SOUTH_EAST,
 	VIPS_GRAVITY_SOUTH_WEST,
-	VIPS_GRAVITY_NORTH_WEST
+	VIPS_GRAVITY_NORTH_WEST,
+	VIPS_GRAVITY_LAST
 } VipsGravity;
 
 int vips_black( VipsImage **out, int width, int height, ... )

--- a/libvips/include/vips/create.h
+++ b/libvips/include/vips/create.h
@@ -38,6 +38,18 @@
 extern "C" {
 #endif /*__cplusplus*/
 
+typedef enum {
+	VIPS_GRAVITY_CENTER,
+	VIPS_GRAVITY_NORTH,
+	VIPS_GRAVITY_EAST,
+	VIPS_GRAVITY_SOUTH,
+	VIPS_GRAVITY_WEST,
+	VIPS_GRAVITY_NORTH_EAST,
+	VIPS_GRAVITY_SOUTH_EAST,
+	VIPS_GRAVITY_SOUTH_WEST,
+	VIPS_GRAVITY_NORTH_WEST
+} VipsGravity;
+
 int vips_black( VipsImage **out, int width, int height, ... )
 	__attribute__((sentinel));
 

--- a/libvips/include/vips/enumtypes.h
+++ b/libvips/include/vips/enumtypes.h
@@ -6,50 +6,14 @@
 
 G_BEGIN_DECLS
 
-/* enumerations from "../../../libvips/include/vips/arithmetic.h" */
-GType vips_operation_math_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_OPERATION_MATH (vips_operation_math_get_type())
-GType vips_operation_math2_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_OPERATION_MATH2 (vips_operation_math2_get_type())
-GType vips_operation_round_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_OPERATION_ROUND (vips_operation_round_get_type())
-GType vips_operation_relational_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_OPERATION_RELATIONAL (vips_operation_relational_get_type())
-GType vips_operation_boolean_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_OPERATION_BOOLEAN (vips_operation_boolean_get_type())
-GType vips_operation_complex_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_OPERATION_COMPLEX (vips_operation_complex_get_type())
-GType vips_operation_complex2_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_OPERATION_COMPLEX2 (vips_operation_complex2_get_type())
-GType vips_operation_complexget_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_OPERATION_COMPLEXGET (vips_operation_complexget_get_type())
-/* enumerations from "../../../libvips/include/vips/basic.h" */
-GType vips_precision_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_PRECISION (vips_precision_get_type())
-/* enumerations from "../../../libvips/include/vips/colour.h" */
-GType vips_intent_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_INTENT (vips_intent_get_type())
-GType vips_pcs_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_PCS (vips_pcs_get_type())
-/* enumerations from "../../../libvips/include/vips/conversion.h" */
-GType vips_extend_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_EXTEND (vips_extend_get_type())
-GType vips_direction_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_DIRECTION (vips_direction_get_type())
-GType vips_align_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_ALIGN (vips_align_get_type())
-GType vips_angle_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_ANGLE (vips_angle_get_type())
-GType vips_angle45_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_ANGLE45 (vips_angle45_get_type())
-GType vips_interesting_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_INTERESTING (vips_interesting_get_type())
-/* enumerations from "../../../libvips/include/vips/convolution.h" */
-GType vips_combine_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_COMBINE (vips_combine_get_type())
-/* enumerations from "../../../libvips/include/vips/draw.h" */
-GType vips_combine_mode_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_COMBINE_MODE (vips_combine_mode_get_type())
+/* enumerations from "../../../libvips/include/vips/resample.h" */
+GType vips_kernel_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_KERNEL (vips_kernel_get_type())
+GType vips_size_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_SIZE (vips_size_get_type())
+/* enumerations from "../../../libvips/include/vips/create.h" */
+GType vips_gravity_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_GRAVITY (vips_gravity_get_type())
 /* enumerations from "../../../libvips/include/vips/foreign.h" */
 GType vips_foreign_flags_get_type (void) G_GNUC_CONST;
 #define VIPS_TYPE_FOREIGN_FLAGS (vips_foreign_flags_get_type())
@@ -71,6 +35,39 @@ GType vips_foreign_dz_depth_get_type (void) G_GNUC_CONST;
 #define VIPS_TYPE_FOREIGN_DZ_DEPTH (vips_foreign_dz_depth_get_type())
 GType vips_foreign_dz_container_get_type (void) G_GNUC_CONST;
 #define VIPS_TYPE_FOREIGN_DZ_CONTAINER (vips_foreign_dz_container_get_type())
+/* enumerations from "../../../libvips/include/vips/arithmetic.h" */
+GType vips_operation_math_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_OPERATION_MATH (vips_operation_math_get_type())
+GType vips_operation_math2_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_OPERATION_MATH2 (vips_operation_math2_get_type())
+GType vips_operation_round_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_OPERATION_ROUND (vips_operation_round_get_type())
+GType vips_operation_relational_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_OPERATION_RELATIONAL (vips_operation_relational_get_type())
+GType vips_operation_boolean_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_OPERATION_BOOLEAN (vips_operation_boolean_get_type())
+GType vips_operation_complex_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_OPERATION_COMPLEX (vips_operation_complex_get_type())
+GType vips_operation_complex2_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_OPERATION_COMPLEX2 (vips_operation_complex2_get_type())
+GType vips_operation_complexget_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_OPERATION_COMPLEXGET (vips_operation_complexget_get_type())
+/* enumerations from "../../../libvips/include/vips/conversion.h" */
+GType vips_extend_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_EXTEND (vips_extend_get_type())
+GType vips_direction_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_DIRECTION (vips_direction_get_type())
+GType vips_align_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_ALIGN (vips_align_get_type())
+GType vips_angle_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_ANGLE (vips_angle_get_type())
+GType vips_angle45_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_ANGLE45 (vips_angle45_get_type())
+GType vips_interesting_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_INTERESTING (vips_interesting_get_type())
+/* enumerations from "../../../libvips/include/vips/util.h" */
+GType vips_token_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_TOKEN (vips_token_get_type())
 /* enumerations from "../../../libvips/include/vips/image.h" */
 GType vips_demand_style_get_type (void) G_GNUC_CONST;
 #define VIPS_TYPE_DEMAND_STYLE (vips_demand_style_get_type())
@@ -84,23 +81,29 @@ GType vips_coding_get_type (void) G_GNUC_CONST;
 #define VIPS_TYPE_CODING (vips_coding_get_type())
 GType vips_access_get_type (void) G_GNUC_CONST;
 #define VIPS_TYPE_ACCESS (vips_access_get_type())
-/* enumerations from "../../../libvips/include/vips/morphology.h" */
-GType vips_operation_morphology_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_OPERATION_MORPHOLOGY (vips_operation_morphology_get_type())
-/* enumerations from "../../../libvips/include/vips/object.h" */
-GType vips_argument_flags_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_ARGUMENT_FLAGS (vips_argument_flags_get_type())
+/* enumerations from "../../../libvips/include/vips/colour.h" */
+GType vips_intent_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_INTENT (vips_intent_get_type())
+GType vips_pcs_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_PCS (vips_pcs_get_type())
 /* enumerations from "../../../libvips/include/vips/operation.h" */
 GType vips_operation_flags_get_type (void) G_GNUC_CONST;
 #define VIPS_TYPE_OPERATION_FLAGS (vips_operation_flags_get_type())
-/* enumerations from "../../../libvips/include/vips/resample.h" */
-GType vips_kernel_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_KERNEL (vips_kernel_get_type())
-GType vips_size_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_SIZE (vips_size_get_type())
-/* enumerations from "../../../libvips/include/vips/util.h" */
-GType vips_token_get_type (void) G_GNUC_CONST;
-#define VIPS_TYPE_TOKEN (vips_token_get_type())
+/* enumerations from "../../../libvips/include/vips/convolution.h" */
+GType vips_combine_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_COMBINE (vips_combine_get_type())
+/* enumerations from "../../../libvips/include/vips/morphology.h" */
+GType vips_operation_morphology_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_OPERATION_MORPHOLOGY (vips_operation_morphology_get_type())
+/* enumerations from "../../../libvips/include/vips/draw.h" */
+GType vips_combine_mode_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_COMBINE_MODE (vips_combine_mode_get_type())
+/* enumerations from "../../../libvips/include/vips/basic.h" */
+GType vips_precision_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_PRECISION (vips_precision_get_type())
+/* enumerations from "../../../libvips/include/vips/object.h" */
+GType vips_argument_flags_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_ARGUMENT_FLAGS (vips_argument_flags_get_type())
 G_END_DECLS
 
 #endif /*VIPS_ENUM_TYPES_H*/

--- a/libvips/iofuncs/enumtypes.c
+++ b/libvips/iofuncs/enumtypes.c
@@ -4,384 +4,69 @@
 /* auto-generated enums for vips introspection */
 
 #include <vips/vips.h>
-/* enumerations from "../../libvips/include/vips/arithmetic.h" */
+/* enumerations from "../../libvips/include/vips/resample.h" */
 GType
-vips_operation_math_get_type( void )
+vips_kernel_get_type( void )
 {
 	static GType etype = 0;
 
 	if( etype == 0 ) {
 		static const GEnumValue values[] = {
-			{VIPS_OPERATION_MATH_SIN, "VIPS_OPERATION_MATH_SIN", "sin"},
-			{VIPS_OPERATION_MATH_COS, "VIPS_OPERATION_MATH_COS", "cos"},
-			{VIPS_OPERATION_MATH_TAN, "VIPS_OPERATION_MATH_TAN", "tan"},
-			{VIPS_OPERATION_MATH_ASIN, "VIPS_OPERATION_MATH_ASIN", "asin"},
-			{VIPS_OPERATION_MATH_ACOS, "VIPS_OPERATION_MATH_ACOS", "acos"},
-			{VIPS_OPERATION_MATH_ATAN, "VIPS_OPERATION_MATH_ATAN", "atan"},
-			{VIPS_OPERATION_MATH_LOG, "VIPS_OPERATION_MATH_LOG", "log"},
-			{VIPS_OPERATION_MATH_LOG10, "VIPS_OPERATION_MATH_LOG10", "log10"},
-			{VIPS_OPERATION_MATH_EXP, "VIPS_OPERATION_MATH_EXP", "exp"},
-			{VIPS_OPERATION_MATH_EXP10, "VIPS_OPERATION_MATH_EXP10", "exp10"},
-			{VIPS_OPERATION_MATH_LAST, "VIPS_OPERATION_MATH_LAST", "last"},
+			{VIPS_KERNEL_NEAREST, "VIPS_KERNEL_NEAREST", "nearest"},
+			{VIPS_KERNEL_LINEAR, "VIPS_KERNEL_LINEAR", "linear"},
+			{VIPS_KERNEL_CUBIC, "VIPS_KERNEL_CUBIC", "cubic"},
+			{VIPS_KERNEL_LANCZOS2, "VIPS_KERNEL_LANCZOS2", "lanczos2"},
+			{VIPS_KERNEL_LANCZOS3, "VIPS_KERNEL_LANCZOS3", "lanczos3"},
+			{VIPS_KERNEL_LAST, "VIPS_KERNEL_LAST", "last"},
 			{0, NULL, NULL}
 		};
 		
-		etype = g_enum_register_static( "VipsOperationMath", values );
+		etype = g_enum_register_static( "VipsKernel", values );
 	}
 
 	return( etype );
 }
 GType
-vips_operation_math2_get_type( void )
+vips_size_get_type( void )
 {
 	static GType etype = 0;
 
 	if( etype == 0 ) {
 		static const GEnumValue values[] = {
-			{VIPS_OPERATION_MATH2_POW, "VIPS_OPERATION_MATH2_POW", "pow"},
-			{VIPS_OPERATION_MATH2_WOP, "VIPS_OPERATION_MATH2_WOP", "wop"},
-			{VIPS_OPERATION_MATH2_LAST, "VIPS_OPERATION_MATH2_LAST", "last"},
+			{VIPS_SIZE_BOTH, "VIPS_SIZE_BOTH", "both"},
+			{VIPS_SIZE_UP, "VIPS_SIZE_UP", "up"},
+			{VIPS_SIZE_DOWN, "VIPS_SIZE_DOWN", "down"},
+			{VIPS_SIZE_FORCE, "VIPS_SIZE_FORCE", "force"},
+			{VIPS_SIZE_LAST, "VIPS_SIZE_LAST", "last"},
 			{0, NULL, NULL}
 		};
 		
-		etype = g_enum_register_static( "VipsOperationMath2", values );
+		etype = g_enum_register_static( "VipsSize", values );
 	}
 
 	return( etype );
 }
+/* enumerations from "../../libvips/include/vips/create.h" */
 GType
-vips_operation_round_get_type( void )
+vips_gravity_get_type( void )
 {
 	static GType etype = 0;
 
 	if( etype == 0 ) {
 		static const GEnumValue values[] = {
-			{VIPS_OPERATION_ROUND_RINT, "VIPS_OPERATION_ROUND_RINT", "rint"},
-			{VIPS_OPERATION_ROUND_CEIL, "VIPS_OPERATION_ROUND_CEIL", "ceil"},
-			{VIPS_OPERATION_ROUND_FLOOR, "VIPS_OPERATION_ROUND_FLOOR", "floor"},
-			{VIPS_OPERATION_ROUND_LAST, "VIPS_OPERATION_ROUND_LAST", "last"},
+			{VIPS_GRAVITY_CENTER, "VIPS_GRAVITY_CENTER", "center"},
+			{VIPS_GRAVITY_NORTH, "VIPS_GRAVITY_NORTH", "north"},
+			{VIPS_GRAVITY_EAST, "VIPS_GRAVITY_EAST", "east"},
+			{VIPS_GRAVITY_SOUTH, "VIPS_GRAVITY_SOUTH", "south"},
+			{VIPS_GRAVITY_WEST, "VIPS_GRAVITY_WEST", "west"},
+			{VIPS_GRAVITY_NORTH_EAST, "VIPS_GRAVITY_NORTH_EAST", "north-east"},
+			{VIPS_GRAVITY_SOUTH_EAST, "VIPS_GRAVITY_SOUTH_EAST", "south-east"},
+			{VIPS_GRAVITY_SOUTH_WEST, "VIPS_GRAVITY_SOUTH_WEST", "south-west"},
+			{VIPS_GRAVITY_NORTH_WEST, "VIPS_GRAVITY_NORTH_WEST", "north-west"},
 			{0, NULL, NULL}
 		};
 		
-		etype = g_enum_register_static( "VipsOperationRound", values );
-	}
-
-	return( etype );
-}
-GType
-vips_operation_relational_get_type( void )
-{
-	static GType etype = 0;
-
-	if( etype == 0 ) {
-		static const GEnumValue values[] = {
-			{VIPS_OPERATION_RELATIONAL_EQUAL, "VIPS_OPERATION_RELATIONAL_EQUAL", "equal"},
-			{VIPS_OPERATION_RELATIONAL_NOTEQ, "VIPS_OPERATION_RELATIONAL_NOTEQ", "noteq"},
-			{VIPS_OPERATION_RELATIONAL_LESS, "VIPS_OPERATION_RELATIONAL_LESS", "less"},
-			{VIPS_OPERATION_RELATIONAL_LESSEQ, "VIPS_OPERATION_RELATIONAL_LESSEQ", "lesseq"},
-			{VIPS_OPERATION_RELATIONAL_MORE, "VIPS_OPERATION_RELATIONAL_MORE", "more"},
-			{VIPS_OPERATION_RELATIONAL_MOREEQ, "VIPS_OPERATION_RELATIONAL_MOREEQ", "moreeq"},
-			{VIPS_OPERATION_RELATIONAL_LAST, "VIPS_OPERATION_RELATIONAL_LAST", "last"},
-			{0, NULL, NULL}
-		};
-		
-		etype = g_enum_register_static( "VipsOperationRelational", values );
-	}
-
-	return( etype );
-}
-GType
-vips_operation_boolean_get_type( void )
-{
-	static GType etype = 0;
-
-	if( etype == 0 ) {
-		static const GEnumValue values[] = {
-			{VIPS_OPERATION_BOOLEAN_AND, "VIPS_OPERATION_BOOLEAN_AND", "and"},
-			{VIPS_OPERATION_BOOLEAN_OR, "VIPS_OPERATION_BOOLEAN_OR", "or"},
-			{VIPS_OPERATION_BOOLEAN_EOR, "VIPS_OPERATION_BOOLEAN_EOR", "eor"},
-			{VIPS_OPERATION_BOOLEAN_LSHIFT, "VIPS_OPERATION_BOOLEAN_LSHIFT", "lshift"},
-			{VIPS_OPERATION_BOOLEAN_RSHIFT, "VIPS_OPERATION_BOOLEAN_RSHIFT", "rshift"},
-			{VIPS_OPERATION_BOOLEAN_LAST, "VIPS_OPERATION_BOOLEAN_LAST", "last"},
-			{0, NULL, NULL}
-		};
-		
-		etype = g_enum_register_static( "VipsOperationBoolean", values );
-	}
-
-	return( etype );
-}
-GType
-vips_operation_complex_get_type( void )
-{
-	static GType etype = 0;
-
-	if( etype == 0 ) {
-		static const GEnumValue values[] = {
-			{VIPS_OPERATION_COMPLEX_POLAR, "VIPS_OPERATION_COMPLEX_POLAR", "polar"},
-			{VIPS_OPERATION_COMPLEX_RECT, "VIPS_OPERATION_COMPLEX_RECT", "rect"},
-			{VIPS_OPERATION_COMPLEX_CONJ, "VIPS_OPERATION_COMPLEX_CONJ", "conj"},
-			{VIPS_OPERATION_COMPLEX_LAST, "VIPS_OPERATION_COMPLEX_LAST", "last"},
-			{0, NULL, NULL}
-		};
-		
-		etype = g_enum_register_static( "VipsOperationComplex", values );
-	}
-
-	return( etype );
-}
-GType
-vips_operation_complex2_get_type( void )
-{
-	static GType etype = 0;
-
-	if( etype == 0 ) {
-		static const GEnumValue values[] = {
-			{VIPS_OPERATION_COMPLEX2_CROSS_PHASE, "VIPS_OPERATION_COMPLEX2_CROSS_PHASE", "cross-phase"},
-			{VIPS_OPERATION_COMPLEX2_LAST, "VIPS_OPERATION_COMPLEX2_LAST", "last"},
-			{0, NULL, NULL}
-		};
-		
-		etype = g_enum_register_static( "VipsOperationComplex2", values );
-	}
-
-	return( etype );
-}
-GType
-vips_operation_complexget_get_type( void )
-{
-	static GType etype = 0;
-
-	if( etype == 0 ) {
-		static const GEnumValue values[] = {
-			{VIPS_OPERATION_COMPLEXGET_REAL, "VIPS_OPERATION_COMPLEXGET_REAL", "real"},
-			{VIPS_OPERATION_COMPLEXGET_IMAG, "VIPS_OPERATION_COMPLEXGET_IMAG", "imag"},
-			{VIPS_OPERATION_COMPLEXGET_LAST, "VIPS_OPERATION_COMPLEXGET_LAST", "last"},
-			{0, NULL, NULL}
-		};
-		
-		etype = g_enum_register_static( "VipsOperationComplexget", values );
-	}
-
-	return( etype );
-}
-/* enumerations from "../../libvips/include/vips/basic.h" */
-GType
-vips_precision_get_type( void )
-{
-	static GType etype = 0;
-
-	if( etype == 0 ) {
-		static const GEnumValue values[] = {
-			{VIPS_PRECISION_INTEGER, "VIPS_PRECISION_INTEGER", "integer"},
-			{VIPS_PRECISION_FLOAT, "VIPS_PRECISION_FLOAT", "float"},
-			{VIPS_PRECISION_APPROXIMATE, "VIPS_PRECISION_APPROXIMATE", "approximate"},
-			{VIPS_PRECISION_LAST, "VIPS_PRECISION_LAST", "last"},
-			{0, NULL, NULL}
-		};
-		
-		etype = g_enum_register_static( "VipsPrecision", values );
-	}
-
-	return( etype );
-}
-/* enumerations from "../../libvips/include/vips/colour.h" */
-GType
-vips_intent_get_type( void )
-{
-	static GType etype = 0;
-
-	if( etype == 0 ) {
-		static const GEnumValue values[] = {
-			{VIPS_INTENT_PERCEPTUAL, "VIPS_INTENT_PERCEPTUAL", "perceptual"},
-			{VIPS_INTENT_RELATIVE, "VIPS_INTENT_RELATIVE", "relative"},
-			{VIPS_INTENT_SATURATION, "VIPS_INTENT_SATURATION", "saturation"},
-			{VIPS_INTENT_ABSOLUTE, "VIPS_INTENT_ABSOLUTE", "absolute"},
-			{VIPS_INTENT_LAST, "VIPS_INTENT_LAST", "last"},
-			{0, NULL, NULL}
-		};
-		
-		etype = g_enum_register_static( "VipsIntent", values );
-	}
-
-	return( etype );
-}
-GType
-vips_pcs_get_type( void )
-{
-	static GType etype = 0;
-
-	if( etype == 0 ) {
-		static const GEnumValue values[] = {
-			{VIPS_PCS_LAB, "VIPS_PCS_LAB", "lab"},
-			{VIPS_PCS_XYZ, "VIPS_PCS_XYZ", "xyz"},
-			{VIPS_PCS_LAST, "VIPS_PCS_LAST", "last"},
-			{0, NULL, NULL}
-		};
-		
-		etype = g_enum_register_static( "VipsPCS", values );
-	}
-
-	return( etype );
-}
-/* enumerations from "../../libvips/include/vips/conversion.h" */
-GType
-vips_extend_get_type( void )
-{
-	static GType etype = 0;
-
-	if( etype == 0 ) {
-		static const GEnumValue values[] = {
-			{VIPS_EXTEND_BLACK, "VIPS_EXTEND_BLACK", "black"},
-			{VIPS_EXTEND_COPY, "VIPS_EXTEND_COPY", "copy"},
-			{VIPS_EXTEND_REPEAT, "VIPS_EXTEND_REPEAT", "repeat"},
-			{VIPS_EXTEND_MIRROR, "VIPS_EXTEND_MIRROR", "mirror"},
-			{VIPS_EXTEND_WHITE, "VIPS_EXTEND_WHITE", "white"},
-			{VIPS_EXTEND_BACKGROUND, "VIPS_EXTEND_BACKGROUND", "background"},
-			{VIPS_EXTEND_LAST, "VIPS_EXTEND_LAST", "last"},
-			{0, NULL, NULL}
-		};
-		
-		etype = g_enum_register_static( "VipsExtend", values );
-	}
-
-	return( etype );
-}
-GType
-vips_direction_get_type( void )
-{
-	static GType etype = 0;
-
-	if( etype == 0 ) {
-		static const GEnumValue values[] = {
-			{VIPS_DIRECTION_HORIZONTAL, "VIPS_DIRECTION_HORIZONTAL", "horizontal"},
-			{VIPS_DIRECTION_VERTICAL, "VIPS_DIRECTION_VERTICAL", "vertical"},
-			{VIPS_DIRECTION_LAST, "VIPS_DIRECTION_LAST", "last"},
-			{0, NULL, NULL}
-		};
-		
-		etype = g_enum_register_static( "VipsDirection", values );
-	}
-
-	return( etype );
-}
-GType
-vips_align_get_type( void )
-{
-	static GType etype = 0;
-
-	if( etype == 0 ) {
-		static const GEnumValue values[] = {
-			{VIPS_ALIGN_LOW, "VIPS_ALIGN_LOW", "low"},
-			{VIPS_ALIGN_CENTRE, "VIPS_ALIGN_CENTRE", "centre"},
-			{VIPS_ALIGN_HIGH, "VIPS_ALIGN_HIGH", "high"},
-			{VIPS_ALIGN_LAST, "VIPS_ALIGN_LAST", "last"},
-			{0, NULL, NULL}
-		};
-		
-		etype = g_enum_register_static( "VipsAlign", values );
-	}
-
-	return( etype );
-}
-GType
-vips_angle_get_type( void )
-{
-	static GType etype = 0;
-
-	if( etype == 0 ) {
-		static const GEnumValue values[] = {
-			{VIPS_ANGLE_D0, "VIPS_ANGLE_D0", "d0"},
-			{VIPS_ANGLE_D90, "VIPS_ANGLE_D90", "d90"},
-			{VIPS_ANGLE_D180, "VIPS_ANGLE_D180", "d180"},
-			{VIPS_ANGLE_D270, "VIPS_ANGLE_D270", "d270"},
-			{VIPS_ANGLE_LAST, "VIPS_ANGLE_LAST", "last"},
-			{0, NULL, NULL}
-		};
-		
-		etype = g_enum_register_static( "VipsAngle", values );
-	}
-
-	return( etype );
-}
-GType
-vips_angle45_get_type( void )
-{
-	static GType etype = 0;
-
-	if( etype == 0 ) {
-		static const GEnumValue values[] = {
-			{VIPS_ANGLE45_D0, "VIPS_ANGLE45_D0", "d0"},
-			{VIPS_ANGLE45_D45, "VIPS_ANGLE45_D45", "d45"},
-			{VIPS_ANGLE45_D90, "VIPS_ANGLE45_D90", "d90"},
-			{VIPS_ANGLE45_D135, "VIPS_ANGLE45_D135", "d135"},
-			{VIPS_ANGLE45_D180, "VIPS_ANGLE45_D180", "d180"},
-			{VIPS_ANGLE45_D225, "VIPS_ANGLE45_D225", "d225"},
-			{VIPS_ANGLE45_D270, "VIPS_ANGLE45_D270", "d270"},
-			{VIPS_ANGLE45_D315, "VIPS_ANGLE45_D315", "d315"},
-			{VIPS_ANGLE45_LAST, "VIPS_ANGLE45_LAST", "last"},
-			{0, NULL, NULL}
-		};
-		
-		etype = g_enum_register_static( "VipsAngle45", values );
-	}
-
-	return( etype );
-}
-GType
-vips_interesting_get_type( void )
-{
-	static GType etype = 0;
-
-	if( etype == 0 ) {
-		static const GEnumValue values[] = {
-			{VIPS_INTERESTING_NONE, "VIPS_INTERESTING_NONE", "none"},
-			{VIPS_INTERESTING_CENTRE, "VIPS_INTERESTING_CENTRE", "centre"},
-			{VIPS_INTERESTING_ENTROPY, "VIPS_INTERESTING_ENTROPY", "entropy"},
-			{VIPS_INTERESTING_ATTENTION, "VIPS_INTERESTING_ATTENTION", "attention"},
-			{VIPS_INTERESTING_LAST, "VIPS_INTERESTING_LAST", "last"},
-			{0, NULL, NULL}
-		};
-		
-		etype = g_enum_register_static( "VipsInteresting", values );
-	}
-
-	return( etype );
-}
-/* enumerations from "../../libvips/include/vips/convolution.h" */
-GType
-vips_combine_get_type( void )
-{
-	static GType etype = 0;
-
-	if( etype == 0 ) {
-		static const GEnumValue values[] = {
-			{VIPS_COMBINE_MAX, "VIPS_COMBINE_MAX", "max"},
-			{VIPS_COMBINE_SUM, "VIPS_COMBINE_SUM", "sum"},
-			{VIPS_COMBINE_LAST, "VIPS_COMBINE_LAST", "last"},
-			{0, NULL, NULL}
-		};
-		
-		etype = g_enum_register_static( "VipsCombine", values );
-	}
-
-	return( etype );
-}
-/* enumerations from "../../libvips/include/vips/draw.h" */
-GType
-vips_combine_mode_get_type( void )
-{
-	static GType etype = 0;
-
-	if( etype == 0 ) {
-		static const GEnumValue values[] = {
-			{VIPS_COMBINE_MODE_SET, "VIPS_COMBINE_MODE_SET", "set"},
-			{VIPS_COMBINE_MODE_ADD, "VIPS_COMBINE_MODE_ADD", "add"},
-			{VIPS_COMBINE_MODE_LAST, "VIPS_COMBINE_MODE_LAST", "last"},
-			{0, NULL, NULL}
-		};
-		
-		etype = g_enum_register_static( "VipsCombineMode", values );
+		etype = g_enum_register_static( "VipsGravity", values );
 	}
 
 	return( etype );
@@ -587,6 +272,312 @@ vips_foreign_dz_container_get_type( void )
 
 	return( etype );
 }
+/* enumerations from "../../libvips/include/vips/conversion.h" */
+GType
+vips_extend_get_type( void )
+{
+	static GType etype = 0;
+
+	if( etype == 0 ) {
+		static const GEnumValue values[] = {
+			{VIPS_EXTEND_BLACK, "VIPS_EXTEND_BLACK", "black"},
+			{VIPS_EXTEND_COPY, "VIPS_EXTEND_COPY", "copy"},
+			{VIPS_EXTEND_REPEAT, "VIPS_EXTEND_REPEAT", "repeat"},
+			{VIPS_EXTEND_MIRROR, "VIPS_EXTEND_MIRROR", "mirror"},
+			{VIPS_EXTEND_WHITE, "VIPS_EXTEND_WHITE", "white"},
+			{VIPS_EXTEND_BACKGROUND, "VIPS_EXTEND_BACKGROUND", "background"},
+			{VIPS_EXTEND_LAST, "VIPS_EXTEND_LAST", "last"},
+			{0, NULL, NULL}
+		};
+		
+		etype = g_enum_register_static( "VipsExtend", values );
+	}
+
+	return( etype );
+}
+GType
+vips_direction_get_type( void )
+{
+	static GType etype = 0;
+
+	if( etype == 0 ) {
+		static const GEnumValue values[] = {
+			{VIPS_DIRECTION_HORIZONTAL, "VIPS_DIRECTION_HORIZONTAL", "horizontal"},
+			{VIPS_DIRECTION_VERTICAL, "VIPS_DIRECTION_VERTICAL", "vertical"},
+			{VIPS_DIRECTION_LAST, "VIPS_DIRECTION_LAST", "last"},
+			{0, NULL, NULL}
+		};
+		
+		etype = g_enum_register_static( "VipsDirection", values );
+	}
+
+	return( etype );
+}
+GType
+vips_align_get_type( void )
+{
+	static GType etype = 0;
+
+	if( etype == 0 ) {
+		static const GEnumValue values[] = {
+			{VIPS_ALIGN_LOW, "VIPS_ALIGN_LOW", "low"},
+			{VIPS_ALIGN_CENTRE, "VIPS_ALIGN_CENTRE", "centre"},
+			{VIPS_ALIGN_HIGH, "VIPS_ALIGN_HIGH", "high"},
+			{VIPS_ALIGN_LAST, "VIPS_ALIGN_LAST", "last"},
+			{0, NULL, NULL}
+		};
+		
+		etype = g_enum_register_static( "VipsAlign", values );
+	}
+
+	return( etype );
+}
+GType
+vips_angle_get_type( void )
+{
+	static GType etype = 0;
+
+	if( etype == 0 ) {
+		static const GEnumValue values[] = {
+			{VIPS_ANGLE_D0, "VIPS_ANGLE_D0", "d0"},
+			{VIPS_ANGLE_D90, "VIPS_ANGLE_D90", "d90"},
+			{VIPS_ANGLE_D180, "VIPS_ANGLE_D180", "d180"},
+			{VIPS_ANGLE_D270, "VIPS_ANGLE_D270", "d270"},
+			{VIPS_ANGLE_LAST, "VIPS_ANGLE_LAST", "last"},
+			{0, NULL, NULL}
+		};
+		
+		etype = g_enum_register_static( "VipsAngle", values );
+	}
+
+	return( etype );
+}
+GType
+vips_angle45_get_type( void )
+{
+	static GType etype = 0;
+
+	if( etype == 0 ) {
+		static const GEnumValue values[] = {
+			{VIPS_ANGLE45_D0, "VIPS_ANGLE45_D0", "d0"},
+			{VIPS_ANGLE45_D45, "VIPS_ANGLE45_D45", "d45"},
+			{VIPS_ANGLE45_D90, "VIPS_ANGLE45_D90", "d90"},
+			{VIPS_ANGLE45_D135, "VIPS_ANGLE45_D135", "d135"},
+			{VIPS_ANGLE45_D180, "VIPS_ANGLE45_D180", "d180"},
+			{VIPS_ANGLE45_D225, "VIPS_ANGLE45_D225", "d225"},
+			{VIPS_ANGLE45_D270, "VIPS_ANGLE45_D270", "d270"},
+			{VIPS_ANGLE45_D315, "VIPS_ANGLE45_D315", "d315"},
+			{VIPS_ANGLE45_LAST, "VIPS_ANGLE45_LAST", "last"},
+			{0, NULL, NULL}
+		};
+		
+		etype = g_enum_register_static( "VipsAngle45", values );
+	}
+
+	return( etype );
+}
+GType
+vips_interesting_get_type( void )
+{
+	static GType etype = 0;
+
+	if( etype == 0 ) {
+		static const GEnumValue values[] = {
+			{VIPS_INTERESTING_NONE, "VIPS_INTERESTING_NONE", "none"},
+			{VIPS_INTERESTING_CENTRE, "VIPS_INTERESTING_CENTRE", "centre"},
+			{VIPS_INTERESTING_ENTROPY, "VIPS_INTERESTING_ENTROPY", "entropy"},
+			{VIPS_INTERESTING_ATTENTION, "VIPS_INTERESTING_ATTENTION", "attention"},
+			{VIPS_INTERESTING_LAST, "VIPS_INTERESTING_LAST", "last"},
+			{0, NULL, NULL}
+		};
+		
+		etype = g_enum_register_static( "VipsInteresting", values );
+	}
+
+	return( etype );
+}
+/* enumerations from "../../libvips/include/vips/arithmetic.h" */
+GType
+vips_operation_math_get_type( void )
+{
+	static GType etype = 0;
+
+	if( etype == 0 ) {
+		static const GEnumValue values[] = {
+			{VIPS_OPERATION_MATH_SIN, "VIPS_OPERATION_MATH_SIN", "sin"},
+			{VIPS_OPERATION_MATH_COS, "VIPS_OPERATION_MATH_COS", "cos"},
+			{VIPS_OPERATION_MATH_TAN, "VIPS_OPERATION_MATH_TAN", "tan"},
+			{VIPS_OPERATION_MATH_ASIN, "VIPS_OPERATION_MATH_ASIN", "asin"},
+			{VIPS_OPERATION_MATH_ACOS, "VIPS_OPERATION_MATH_ACOS", "acos"},
+			{VIPS_OPERATION_MATH_ATAN, "VIPS_OPERATION_MATH_ATAN", "atan"},
+			{VIPS_OPERATION_MATH_LOG, "VIPS_OPERATION_MATH_LOG", "log"},
+			{VIPS_OPERATION_MATH_LOG10, "VIPS_OPERATION_MATH_LOG10", "log10"},
+			{VIPS_OPERATION_MATH_EXP, "VIPS_OPERATION_MATH_EXP", "exp"},
+			{VIPS_OPERATION_MATH_EXP10, "VIPS_OPERATION_MATH_EXP10", "exp10"},
+			{VIPS_OPERATION_MATH_LAST, "VIPS_OPERATION_MATH_LAST", "last"},
+			{0, NULL, NULL}
+		};
+		
+		etype = g_enum_register_static( "VipsOperationMath", values );
+	}
+
+	return( etype );
+}
+GType
+vips_operation_math2_get_type( void )
+{
+	static GType etype = 0;
+
+	if( etype == 0 ) {
+		static const GEnumValue values[] = {
+			{VIPS_OPERATION_MATH2_POW, "VIPS_OPERATION_MATH2_POW", "pow"},
+			{VIPS_OPERATION_MATH2_WOP, "VIPS_OPERATION_MATH2_WOP", "wop"},
+			{VIPS_OPERATION_MATH2_LAST, "VIPS_OPERATION_MATH2_LAST", "last"},
+			{0, NULL, NULL}
+		};
+		
+		etype = g_enum_register_static( "VipsOperationMath2", values );
+	}
+
+	return( etype );
+}
+GType
+vips_operation_round_get_type( void )
+{
+	static GType etype = 0;
+
+	if( etype == 0 ) {
+		static const GEnumValue values[] = {
+			{VIPS_OPERATION_ROUND_RINT, "VIPS_OPERATION_ROUND_RINT", "rint"},
+			{VIPS_OPERATION_ROUND_CEIL, "VIPS_OPERATION_ROUND_CEIL", "ceil"},
+			{VIPS_OPERATION_ROUND_FLOOR, "VIPS_OPERATION_ROUND_FLOOR", "floor"},
+			{VIPS_OPERATION_ROUND_LAST, "VIPS_OPERATION_ROUND_LAST", "last"},
+			{0, NULL, NULL}
+		};
+		
+		etype = g_enum_register_static( "VipsOperationRound", values );
+	}
+
+	return( etype );
+}
+GType
+vips_operation_relational_get_type( void )
+{
+	static GType etype = 0;
+
+	if( etype == 0 ) {
+		static const GEnumValue values[] = {
+			{VIPS_OPERATION_RELATIONAL_EQUAL, "VIPS_OPERATION_RELATIONAL_EQUAL", "equal"},
+			{VIPS_OPERATION_RELATIONAL_NOTEQ, "VIPS_OPERATION_RELATIONAL_NOTEQ", "noteq"},
+			{VIPS_OPERATION_RELATIONAL_LESS, "VIPS_OPERATION_RELATIONAL_LESS", "less"},
+			{VIPS_OPERATION_RELATIONAL_LESSEQ, "VIPS_OPERATION_RELATIONAL_LESSEQ", "lesseq"},
+			{VIPS_OPERATION_RELATIONAL_MORE, "VIPS_OPERATION_RELATIONAL_MORE", "more"},
+			{VIPS_OPERATION_RELATIONAL_MOREEQ, "VIPS_OPERATION_RELATIONAL_MOREEQ", "moreeq"},
+			{VIPS_OPERATION_RELATIONAL_LAST, "VIPS_OPERATION_RELATIONAL_LAST", "last"},
+			{0, NULL, NULL}
+		};
+		
+		etype = g_enum_register_static( "VipsOperationRelational", values );
+	}
+
+	return( etype );
+}
+GType
+vips_operation_boolean_get_type( void )
+{
+	static GType etype = 0;
+
+	if( etype == 0 ) {
+		static const GEnumValue values[] = {
+			{VIPS_OPERATION_BOOLEAN_AND, "VIPS_OPERATION_BOOLEAN_AND", "and"},
+			{VIPS_OPERATION_BOOLEAN_OR, "VIPS_OPERATION_BOOLEAN_OR", "or"},
+			{VIPS_OPERATION_BOOLEAN_EOR, "VIPS_OPERATION_BOOLEAN_EOR", "eor"},
+			{VIPS_OPERATION_BOOLEAN_LSHIFT, "VIPS_OPERATION_BOOLEAN_LSHIFT", "lshift"},
+			{VIPS_OPERATION_BOOLEAN_RSHIFT, "VIPS_OPERATION_BOOLEAN_RSHIFT", "rshift"},
+			{VIPS_OPERATION_BOOLEAN_LAST, "VIPS_OPERATION_BOOLEAN_LAST", "last"},
+			{0, NULL, NULL}
+		};
+		
+		etype = g_enum_register_static( "VipsOperationBoolean", values );
+	}
+
+	return( etype );
+}
+GType
+vips_operation_complex_get_type( void )
+{
+	static GType etype = 0;
+
+	if( etype == 0 ) {
+		static const GEnumValue values[] = {
+			{VIPS_OPERATION_COMPLEX_POLAR, "VIPS_OPERATION_COMPLEX_POLAR", "polar"},
+			{VIPS_OPERATION_COMPLEX_RECT, "VIPS_OPERATION_COMPLEX_RECT", "rect"},
+			{VIPS_OPERATION_COMPLEX_CONJ, "VIPS_OPERATION_COMPLEX_CONJ", "conj"},
+			{VIPS_OPERATION_COMPLEX_LAST, "VIPS_OPERATION_COMPLEX_LAST", "last"},
+			{0, NULL, NULL}
+		};
+		
+		etype = g_enum_register_static( "VipsOperationComplex", values );
+	}
+
+	return( etype );
+}
+GType
+vips_operation_complex2_get_type( void )
+{
+	static GType etype = 0;
+
+	if( etype == 0 ) {
+		static const GEnumValue values[] = {
+			{VIPS_OPERATION_COMPLEX2_CROSS_PHASE, "VIPS_OPERATION_COMPLEX2_CROSS_PHASE", "cross-phase"},
+			{VIPS_OPERATION_COMPLEX2_LAST, "VIPS_OPERATION_COMPLEX2_LAST", "last"},
+			{0, NULL, NULL}
+		};
+		
+		etype = g_enum_register_static( "VipsOperationComplex2", values );
+	}
+
+	return( etype );
+}
+GType
+vips_operation_complexget_get_type( void )
+{
+	static GType etype = 0;
+
+	if( etype == 0 ) {
+		static const GEnumValue values[] = {
+			{VIPS_OPERATION_COMPLEXGET_REAL, "VIPS_OPERATION_COMPLEXGET_REAL", "real"},
+			{VIPS_OPERATION_COMPLEXGET_IMAG, "VIPS_OPERATION_COMPLEXGET_IMAG", "imag"},
+			{VIPS_OPERATION_COMPLEXGET_LAST, "VIPS_OPERATION_COMPLEXGET_LAST", "last"},
+			{0, NULL, NULL}
+		};
+		
+		etype = g_enum_register_static( "VipsOperationComplexget", values );
+	}
+
+	return( etype );
+}
+/* enumerations from "../../libvips/include/vips/util.h" */
+GType
+vips_token_get_type( void )
+{
+	static GType etype = 0;
+
+	if( etype == 0 ) {
+		static const GEnumValue values[] = {
+			{VIPS_TOKEN_LEFT, "VIPS_TOKEN_LEFT", "left"},
+			{VIPS_TOKEN_RIGHT, "VIPS_TOKEN_RIGHT", "right"},
+			{VIPS_TOKEN_STRING, "VIPS_TOKEN_STRING", "string"},
+			{VIPS_TOKEN_EQUALS, "VIPS_TOKEN_EQUALS", "equals"},
+			{VIPS_TOKEN_COMMA, "VIPS_TOKEN_COMMA", "comma"},
+			{0, NULL, NULL}
+		};
+		
+		etype = g_enum_register_static( "VipsToken", values );
+	}
+
+	return( etype );
+}
 /* enumerations from "../../libvips/include/vips/image.h" */
 GType
 vips_demand_style_get_type( void )
@@ -734,46 +725,41 @@ vips_access_get_type( void )
 
 	return( etype );
 }
-/* enumerations from "../../libvips/include/vips/morphology.h" */
+/* enumerations from "../../libvips/include/vips/colour.h" */
 GType
-vips_operation_morphology_get_type( void )
+vips_intent_get_type( void )
 {
 	static GType etype = 0;
 
 	if( etype == 0 ) {
 		static const GEnumValue values[] = {
-			{VIPS_OPERATION_MORPHOLOGY_ERODE, "VIPS_OPERATION_MORPHOLOGY_ERODE", "erode"},
-			{VIPS_OPERATION_MORPHOLOGY_DILATE, "VIPS_OPERATION_MORPHOLOGY_DILATE", "dilate"},
-			{VIPS_OPERATION_MORPHOLOGY_LAST, "VIPS_OPERATION_MORPHOLOGY_LAST", "last"},
+			{VIPS_INTENT_PERCEPTUAL, "VIPS_INTENT_PERCEPTUAL", "perceptual"},
+			{VIPS_INTENT_RELATIVE, "VIPS_INTENT_RELATIVE", "relative"},
+			{VIPS_INTENT_SATURATION, "VIPS_INTENT_SATURATION", "saturation"},
+			{VIPS_INTENT_ABSOLUTE, "VIPS_INTENT_ABSOLUTE", "absolute"},
+			{VIPS_INTENT_LAST, "VIPS_INTENT_LAST", "last"},
 			{0, NULL, NULL}
 		};
 		
-		etype = g_enum_register_static( "VipsOperationMorphology", values );
+		etype = g_enum_register_static( "VipsIntent", values );
 	}
 
 	return( etype );
 }
-/* enumerations from "../../libvips/include/vips/object.h" */
 GType
-vips_argument_flags_get_type( void )
+vips_pcs_get_type( void )
 {
 	static GType etype = 0;
 
 	if( etype == 0 ) {
-		static const GFlagsValue values[] = {
-			{VIPS_ARGUMENT_NONE, "VIPS_ARGUMENT_NONE", "none"},
-			{VIPS_ARGUMENT_REQUIRED, "VIPS_ARGUMENT_REQUIRED", "required"},
-			{VIPS_ARGUMENT_CONSTRUCT, "VIPS_ARGUMENT_CONSTRUCT", "construct"},
-			{VIPS_ARGUMENT_SET_ONCE, "VIPS_ARGUMENT_SET_ONCE", "set-once"},
-			{VIPS_ARGUMENT_SET_ALWAYS, "VIPS_ARGUMENT_SET_ALWAYS", "set-always"},
-			{VIPS_ARGUMENT_INPUT, "VIPS_ARGUMENT_INPUT", "input"},
-			{VIPS_ARGUMENT_OUTPUT, "VIPS_ARGUMENT_OUTPUT", "output"},
-			{VIPS_ARGUMENT_DEPRECATED, "VIPS_ARGUMENT_DEPRECATED", "deprecated"},
-			{VIPS_ARGUMENT_MODIFY, "VIPS_ARGUMENT_MODIFY", "modify"},
+		static const GEnumValue values[] = {
+			{VIPS_PCS_LAB, "VIPS_PCS_LAB", "lab"},
+			{VIPS_PCS_XYZ, "VIPS_PCS_XYZ", "xyz"},
+			{VIPS_PCS_LAST, "VIPS_PCS_LAST", "last"},
 			{0, NULL, NULL}
 		};
 		
-		etype = g_flags_register_static( "VipsArgumentFlags", values );
+		etype = g_enum_register_static( "VipsPCS", values );
 	}
 
 	return( etype );
@@ -799,65 +785,104 @@ vips_operation_flags_get_type( void )
 
 	return( etype );
 }
-/* enumerations from "../../libvips/include/vips/resample.h" */
+/* enumerations from "../../libvips/include/vips/convolution.h" */
 GType
-vips_kernel_get_type( void )
+vips_combine_get_type( void )
 {
 	static GType etype = 0;
 
 	if( etype == 0 ) {
 		static const GEnumValue values[] = {
-			{VIPS_KERNEL_NEAREST, "VIPS_KERNEL_NEAREST", "nearest"},
-			{VIPS_KERNEL_LINEAR, "VIPS_KERNEL_LINEAR", "linear"},
-			{VIPS_KERNEL_CUBIC, "VIPS_KERNEL_CUBIC", "cubic"},
-			{VIPS_KERNEL_LANCZOS2, "VIPS_KERNEL_LANCZOS2", "lanczos2"},
-			{VIPS_KERNEL_LANCZOS3, "VIPS_KERNEL_LANCZOS3", "lanczos3"},
-			{VIPS_KERNEL_LAST, "VIPS_KERNEL_LAST", "last"},
+			{VIPS_COMBINE_MAX, "VIPS_COMBINE_MAX", "max"},
+			{VIPS_COMBINE_SUM, "VIPS_COMBINE_SUM", "sum"},
+			{VIPS_COMBINE_LAST, "VIPS_COMBINE_LAST", "last"},
 			{0, NULL, NULL}
 		};
 		
-		etype = g_enum_register_static( "VipsKernel", values );
+		etype = g_enum_register_static( "VipsCombine", values );
 	}
 
 	return( etype );
 }
+/* enumerations from "../../libvips/include/vips/morphology.h" */
 GType
-vips_size_get_type( void )
+vips_operation_morphology_get_type( void )
 {
 	static GType etype = 0;
 
 	if( etype == 0 ) {
 		static const GEnumValue values[] = {
-			{VIPS_SIZE_BOTH, "VIPS_SIZE_BOTH", "both"},
-			{VIPS_SIZE_UP, "VIPS_SIZE_UP", "up"},
-			{VIPS_SIZE_DOWN, "VIPS_SIZE_DOWN", "down"},
-			{VIPS_SIZE_FORCE, "VIPS_SIZE_FORCE", "force"},
-			{VIPS_SIZE_LAST, "VIPS_SIZE_LAST", "last"},
+			{VIPS_OPERATION_MORPHOLOGY_ERODE, "VIPS_OPERATION_MORPHOLOGY_ERODE", "erode"},
+			{VIPS_OPERATION_MORPHOLOGY_DILATE, "VIPS_OPERATION_MORPHOLOGY_DILATE", "dilate"},
+			{VIPS_OPERATION_MORPHOLOGY_LAST, "VIPS_OPERATION_MORPHOLOGY_LAST", "last"},
 			{0, NULL, NULL}
 		};
 		
-		etype = g_enum_register_static( "VipsSize", values );
+		etype = g_enum_register_static( "VipsOperationMorphology", values );
 	}
 
 	return( etype );
 }
-/* enumerations from "../../libvips/include/vips/util.h" */
+/* enumerations from "../../libvips/include/vips/draw.h" */
 GType
-vips_token_get_type( void )
+vips_combine_mode_get_type( void )
 {
 	static GType etype = 0;
 
 	if( etype == 0 ) {
 		static const GEnumValue values[] = {
-			{VIPS_TOKEN_LEFT, "VIPS_TOKEN_LEFT", "left"},
-			{VIPS_TOKEN_RIGHT, "VIPS_TOKEN_RIGHT", "right"},
-			{VIPS_TOKEN_STRING, "VIPS_TOKEN_STRING", "string"},
-			{VIPS_TOKEN_EQUALS, "VIPS_TOKEN_EQUALS", "equals"},
-			{VIPS_TOKEN_COMMA, "VIPS_TOKEN_COMMA", "comma"},
+			{VIPS_COMBINE_MODE_SET, "VIPS_COMBINE_MODE_SET", "set"},
+			{VIPS_COMBINE_MODE_ADD, "VIPS_COMBINE_MODE_ADD", "add"},
+			{VIPS_COMBINE_MODE_LAST, "VIPS_COMBINE_MODE_LAST", "last"},
 			{0, NULL, NULL}
 		};
 		
-		etype = g_enum_register_static( "VipsToken", values );
+		etype = g_enum_register_static( "VipsCombineMode", values );
+	}
+
+	return( etype );
+}
+/* enumerations from "../../libvips/include/vips/basic.h" */
+GType
+vips_precision_get_type( void )
+{
+	static GType etype = 0;
+
+	if( etype == 0 ) {
+		static const GEnumValue values[] = {
+			{VIPS_PRECISION_INTEGER, "VIPS_PRECISION_INTEGER", "integer"},
+			{VIPS_PRECISION_FLOAT, "VIPS_PRECISION_FLOAT", "float"},
+			{VIPS_PRECISION_APPROXIMATE, "VIPS_PRECISION_APPROXIMATE", "approximate"},
+			{VIPS_PRECISION_LAST, "VIPS_PRECISION_LAST", "last"},
+			{0, NULL, NULL}
+		};
+		
+		etype = g_enum_register_static( "VipsPrecision", values );
+	}
+
+	return( etype );
+}
+/* enumerations from "../../libvips/include/vips/object.h" */
+GType
+vips_argument_flags_get_type( void )
+{
+	static GType etype = 0;
+
+	if( etype == 0 ) {
+		static const GFlagsValue values[] = {
+			{VIPS_ARGUMENT_NONE, "VIPS_ARGUMENT_NONE", "none"},
+			{VIPS_ARGUMENT_REQUIRED, "VIPS_ARGUMENT_REQUIRED", "required"},
+			{VIPS_ARGUMENT_CONSTRUCT, "VIPS_ARGUMENT_CONSTRUCT", "construct"},
+			{VIPS_ARGUMENT_SET_ONCE, "VIPS_ARGUMENT_SET_ONCE", "set-once"},
+			{VIPS_ARGUMENT_SET_ALWAYS, "VIPS_ARGUMENT_SET_ALWAYS", "set-always"},
+			{VIPS_ARGUMENT_INPUT, "VIPS_ARGUMENT_INPUT", "input"},
+			{VIPS_ARGUMENT_OUTPUT, "VIPS_ARGUMENT_OUTPUT", "output"},
+			{VIPS_ARGUMENT_DEPRECATED, "VIPS_ARGUMENT_DEPRECATED", "deprecated"},
+			{VIPS_ARGUMENT_MODIFY, "VIPS_ARGUMENT_MODIFY", "modify"},
+			{0, NULL, NULL}
+		};
+		
+		etype = g_flags_register_static( "VipsArgumentFlags", values );
 	}
 
 	return( etype );

--- a/libvips/iofuncs/enumtypes.c
+++ b/libvips/iofuncs/enumtypes.c
@@ -63,6 +63,7 @@ vips_gravity_get_type( void )
 			{VIPS_GRAVITY_SOUTH_EAST, "VIPS_GRAVITY_SOUTH_EAST", "south-east"},
 			{VIPS_GRAVITY_SOUTH_WEST, "VIPS_GRAVITY_SOUTH_WEST", "south-west"},
 			{VIPS_GRAVITY_NORTH_WEST, "VIPS_GRAVITY_NORTH_WEST", "north-west"},
+			{VIPS_GRAVITY_LAST, "VIPS_GRAVITY_LAST", "last"},
 			{0, NULL, NULL}
 		};
 		


### PR DESCRIPTION
This PR implements auto fitting of text in requested dimensions.

Two new flags were added to `vips text` to achieve this. `text` now supports `--height gint` and `--gravity VIPS_GRAVITY` to determine the position, and font size of the text automatically.

To autofit text, one needs to use `vips text` like:
```
vips text out.png "input text here" --font "Font Name" --width XXX --height XXX
```

The following table summarizes how different flags work to create a text output image. Font Size takes priority over others, and no autofit logic is applied if the user has specified a font size. The older behavior of `vips text` is preserved for user specified font size.

Font Size | Width | Height | Will text autofit?
--|--|--|--
✗ | ✗ | ✗ | ✗
✗ | ✓ | ✗ | ✗ 
✗ | ✗ | ✓ | ✗
✗ | ✓ | ✓ | ✓

As evident, `height` by itself does not have any effect on the autofit.

To make the process efficient, binary search is used to figure out the font size that has least deviation to requested dimensions. Incremental changes are made after a loosely fitting value of font size is obtained.

This is not a perfect working version of the implementation, it fails horribly for a single letter being autofit, however, it works just fine for most practical purposes. I have tested this thoroughly for edge cases, and have been using it in production for quite some time now. There is, however, quite some scope for improvement.

@jcupitt Comments welcomed. I have tried to maintain full backward compatibility, so any application using `vips text` the way it was before should not be harmed by this.