### PR TITLE
Add C header to GIR file

### DIFF
--- a/libvips/Makefile.am
+++ b/libvips/Makefile.am
@@ -105,14 +105,15 @@ Vips_8_0_gir_LIBS = libvips.la
 Vips_8_0_gir_FILES = $(introspection_sources)
 INTROSPECTION_GIRS += Vips-8.0.gir
 
-# don't use 
-#   --warn-all --verbose 
+# don't use
+#   --warn-all --verbose
 # too annoying
 Vips_8_0_gir_SCANNERFLAGS = \
 	--program=./introspect$(EXEEXT) \
 	--identifier-prefix=Vips \
 	--identifier-prefix=vips \
-	--symbol-prefix=vips 
+	--symbol-prefix=vips \
+	--c-include=vips/vips.h
 
 girdir = $(datadir)/gir-1.0
 gir_DATA = $(INTROSPECTION_GIRS)


### PR DESCRIPTION
This patch adds the `--c-include` option to the `g-ir-scanner` options in the build system. It enables the main C header, `vips/vips.h`, to be identified in the GIR. This is needed by bindings generated for Vala.