### PR TITLE
cplusplus: offset coords are int rather than double

### DIFF
--- a/cplusplus/include/vips/VImage8.h
+++ b/cplusplus/include/vips/VImage8.h
@@ -307,13 +307,13 @@ public:
 		return( vips_image_get_yres( get_image() ) ); 
 	}
 
-	double 
+	int
 	xoffset()
 	{
 		return( vips_image_get_xoffset( get_image() ) ); 
 	}
 
-	double 
+	int
 	yoffset()
 	{
 		return( vips_image_get_yoffset( get_image() ) ); 


### PR DESCRIPTION
Hi John, I spotted this small API gotcha in the C++ bindings, mostly harmless but worth fixing even though it's a breaking change.