### PR TITLE
Remove additional install of pkg-config and automake from macOS CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ matrix:
       before_install:
         - brew tap homebrew/science
         - brew update
-        - brew install ccache pkg-config automake
+        - brew install ccache
         - brew install --ignore-dependencies gtk-doc
         - brew install
           gobject-introspection
@@ -81,5 +81,5 @@ matrix:
           cfitsio libmatio
           orc little-cms2 poppler
           pango libgsf openslide
-          librsvg giflib openexr
+          librsvg openexr
         - brew install pygobject3


### PR DESCRIPTION
It look as though the Travis build for macOS is failing because brew errors
out when it finds pkg-config and automake have already been installed.