### PR TITLE
Update GObject introspection annotations for /libvips/arithmetic

### DIFF
--- a/libvips/arithmetic/abs.c
+++ b/libvips/arithmetic/abs.c
@@ -253,9 +253,9 @@ vips_abs_init( VipsAbs *abs )
 }
 
 /** 
- * vips_abs:
+ * vips_abs: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * This operation finds the absolute value of an image. It does a copy for 

--- a/libvips/arithmetic/add.c
+++ b/libvips/arithmetic/add.c
@@ -185,7 +185,7 @@ vips_add_init( VipsAdd *add )
  * vips_add:
  * @left: input image 
  * @right: input image 
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * This operation calculates @in1 + @in2 and writes the result to @out. 

--- a/libvips/arithmetic/boolean.c
+++ b/libvips/arithmetic/boolean.c
@@ -240,7 +240,7 @@ vips_booleanv( VipsImage *left, VipsImage *right, VipsImage **out,
  * vips_boolean:
  * @left: left-hand input #VipsImage
  * @right: right-hand input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @boolean: boolean operation to perform
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -284,7 +284,7 @@ vips_boolean( VipsImage *left, VipsImage *right, VipsImage **out,
  * vips_andimage:
  * @left: left-hand input #VipsImage
  * @right: right-hand input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_BOOLEAN_AND on a pair of images. See
@@ -310,7 +310,7 @@ vips_andimage( VipsImage *left, VipsImage *right, VipsImage **out, ... )
  * vips_orimage:
  * @left: left-hand input #VipsImage
  * @right: right-hand input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_BOOLEAN_OR on a pair of images. See
@@ -336,7 +336,7 @@ vips_orimage( VipsImage *left, VipsImage *right, VipsImage **out, ... )
  * vips_eorimage:
  * @left: left-hand input #VipsImage
  * @right: right-hand input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_BOOLEAN_EOR on a pair of images. See
@@ -362,7 +362,7 @@ vips_eorimage( VipsImage *left, VipsImage *right, VipsImage **out, ... )
  * vips_lshift:
  * @left: left-hand input #VipsImage
  * @right: right-hand input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_BOOLEAN_LSHIFT on a pair of images. See
@@ -388,7 +388,7 @@ vips_lshift( VipsImage *left, VipsImage *right, VipsImage **out, ... )
  * vips_rshift:
  * @left: left-hand input #VipsImage
  * @right: right-hand input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_BOOLEAN_RSHIFT on a pair of images. See
@@ -554,11 +554,11 @@ vips_boolean_constv( VipsImage *in, VipsImage **out,
 }
 
 /**
- * vips_boolean_const:
+ * vips_boolean_const: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @boolean: boolean operation to perform
- * @c: array of constants 
+ * @c: (array length=n): array of constants
  * @n: number of constants in @c
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -593,10 +593,10 @@ vips_boolean_const( VipsImage *in, VipsImage **out,
 }
 
 /**
- * vips_andimage_const:
+ * vips_andimage_const: (method)
  * @in: input image
- * @out: output image
- * @c: array of constants 
+ * @out: (out): output image
+ * @c: (array length=n): array of constants
  * @n: number of constants in @c
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -622,10 +622,10 @@ vips_andimage_const( VipsImage *in, VipsImage **out, double *c, int n, ... )
 }
 
 /**
- * vips_orimage_const:
+ * vips_orimage_const: (method)
  * @in: input image
- * @out: output image
- * @c: array of constants 
+ * @out: (out): output image
+ * @c: (array length=n): array of constants
  * @n: number of constants in @c
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -651,10 +651,10 @@ vips_orimage_const( VipsImage *in, VipsImage **out, double *c, int n, ... )
 }
 
 /**
- * vips_eorimage_const:
+ * vips_eorimage_const: (method)
  * @in: input image
- * @out: output image
- * @c: array of constants 
+ * @out: (out): output image
+ * @c: (array length=n): array of constants
  * @n: number of constants in @c
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -680,10 +680,10 @@ vips_eorimage_const( VipsImage *in, VipsImage **out, double *c, int n, ... )
 }
 
 /**
- * vips_lshift_const:
+ * vips_lshift_const: (method)
  * @in: input image
- * @out: output image
- * @c: array of constants 
+ * @out: (out): output image
+ * @c: (array length=n): array of constants
  * @n: number of constants in @c
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -709,10 +709,10 @@ vips_lshift_const( VipsImage *in, VipsImage **out, double *c, int n, ... )
 }
 
 /**
- * vips_rshift_const:
+ * vips_rshift_const: (method)
  * @in: input image
- * @out: output image
- * @c: array of constants 
+ * @out: (out): output image
+ * @c: (array length=n): array of constants
  * @n: number of constants in @c
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -738,9 +738,9 @@ vips_rshift_const( VipsImage *in, VipsImage **out, double *c, int n, ... )
 }
 
 /**
- * vips_boolean_const1:
+ * vips_boolean_const1: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @boolean: boolean operation to perform
  * @c: constant 
  * @...: %NULL-terminated list of optional named arguments
@@ -767,9 +767,9 @@ vips_boolean_const1( VipsImage *in, VipsImage **out,
 }
 
 /**
- * vips_andimage_const1:
+ * vips_andimage_const1: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @c: constant 
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -795,9 +795,9 @@ vips_andimage_const1( VipsImage *in, VipsImage **out, double c, ... )
 }
 
 /**
- * vips_orimage_const1:
+ * vips_orimage_const1: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @c: constant 
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -823,9 +823,9 @@ vips_orimage_const1( VipsImage *in, VipsImage **out, double c, ... )
 }
 
 /**
- * vips_eorimage_const1:
+ * vips_eorimage_const1: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @c: constant 
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -851,9 +851,9 @@ vips_eorimage_const1( VipsImage *in, VipsImage **out, double c, ... )
 }
 
 /**
- * vips_lshift_const1:
+ * vips_lshift_const1: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @c: constant 
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -879,9 +879,9 @@ vips_lshift_const1( VipsImage *in, VipsImage **out, double c, ... )
 }
 
 /**
- * vips_rshift_const1:
+ * vips_rshift_const1: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @c: constant 
  * @...: %NULL-terminated list of optional named arguments
  *

--- a/libvips/arithmetic/complex.c
+++ b/libvips/arithmetic/complex.c
@@ -272,9 +272,9 @@ vips_complexv( VipsImage *in, VipsImage **out,
 }
 
 /**
- * vips_complex:
+ * vips_complex: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @cmplx: complex operation to perform
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -299,9 +299,9 @@ vips_complex( VipsImage *in, VipsImage **out, VipsOperationComplex cmplx, ... )
 }
 
 /**
- * vips_polar:
+ * vips_polar: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_COMPLEX_POLAR on an image. See vips_complex().
@@ -322,9 +322,9 @@ vips_polar( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_rect:
+ * vips_rect: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_COMPLEX_RECT on an image. See vips_complex().
@@ -345,9 +345,9 @@ vips_rect( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_conj:
+ * vips_conj: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_COMPLEX_CONJ on an image. See vips_complex().
@@ -569,7 +569,7 @@ vips_complex2v( VipsImage *left, VipsImage *right, VipsImage **out,
  * vips_complex2:
  * @left: input #VipsImage
  * @right: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @cmplx: complex2 operation to perform
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -598,7 +598,7 @@ vips_complex2( VipsImage *left, VipsImage *right, VipsImage **out,
  * vips_cross_phase:
  * @left: input #VipsImage
  * @right: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_COMPLEX2_CROSS_PHASE on an image. 
@@ -781,9 +781,9 @@ vips_complexgetv( VipsImage *in, VipsImage **out,
 }
 
 /**
- * vips_complexget:
+ * vips_complexget: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @get: complex operation to perform
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -810,9 +810,9 @@ vips_complexget( VipsImage *in, VipsImage **out,
 }
 
 /**
- * vips_real:
+ * vips_real: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_COMPLEXGET_REAL on an image. See vips_complexget().
@@ -834,9 +834,9 @@ vips_real( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_imag:
+ * vips_imag: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_COMPLEXGET_IMAG on an image. See vips_complexget().
@@ -977,7 +977,7 @@ vips_complexform_init( VipsComplexform *complexform )
  * vips_complexform:
  * @left: input image 
  * @right: input image 
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Compose two real images to make a complex image. If either @left or @right 

--- a/libvips/arithmetic/deviate.c
+++ b/libvips/arithmetic/deviate.c
@@ -231,9 +231,9 @@ vips_deviate_init( VipsDeviate *deviate )
 }
 
 /**
- * vips_deviate:
+ * vips_deviate: (method)
  * @in: input #VipsImage
- * @out: output pixel standard deviation
+ * @out: (out): output pixel standard deviation
  * @...: %NULL-terminated list of optional named arguments
  *
  * This operation finds the standard deviation of all pixels in @in. It 

--- a/libvips/arithmetic/divide.c
+++ b/libvips/arithmetic/divide.c
@@ -238,7 +238,7 @@ vips_divide_init( VipsDivide *divide )
  * vips_divide:
  * @left: input image 
  * @right: input image 
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * This operation calculates @in1 / @in2 and writes the result to @out. If any

--- a/libvips/arithmetic/find_trim.c
+++ b/libvips/arithmetic/find_trim.c
@@ -237,12 +237,12 @@ vips_find_trim_init( VipsFindTrim *find_trim )
 }
 
 /**
- * vips_find_trim:
+ * vips_find_trim: (method)
  * @in: image to find_trim
- * @left: output left edge
- * @top: output top edge
- * @width: output width
- * @height: output height
+ * @left: (out): output left edge
+ * @top: (out): output top edge
+ * @width: (out): output width
+ * @height: (out): output height
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/arithmetic/getpoint.c
+++ b/libvips/arithmetic/getpoint.c
@@ -166,9 +166,9 @@ vips_getpoint_init( VipsGetpoint *getpoint )
 }
 
 /**
- * vips_getpoint:
+ * vips_getpoint: (method)
  * @in: image to read from
- * @vector: array length=n: output pixel value here
+ * @vector: (out)(array length=n): output pixel value here
  * @n: length of output vector
  * @x: position to read
  * @y: position to read

--- a/libvips/arithmetic/hist_find.c
+++ b/libvips/arithmetic/hist_find.c
@@ -468,9 +468,9 @@ vips_hist_find_init( VipsHistFind *hist_find )
 }
 
 /**
- * vips_hist_find:
+ * vips_hist_find: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/arithmetic/hist_find_indexed.c
+++ b/libvips/arithmetic/hist_find_indexed.c
@@ -401,10 +401,10 @@ vips_hist_find_indexed_init( VipsHistFindIndexed *hist_find )
 }
 
 /**
- * vips_hist_find_indexed:
- * @in: input image
- * @index: input index image 
- * @out: output image
+ * vips_hist_find_indexed: (method)
+ * @in: input #VipsImage
+ * @index: input index #VipsImage
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Make a histogram of @in, but use image @index to pick the bins. In other

--- a/libvips/arithmetic/hist_find_ndim.c
+++ b/libvips/arithmetic/hist_find_ndim.c
@@ -316,9 +316,9 @@ vips_hist_find_ndim_init( VipsHistFindNDim *ndim )
 }
 
 /**
- * vips_hist_find_ndim:
+ * vips_hist_find_ndim: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/arithmetic/hough_circle.c
+++ b/libvips/arithmetic/hough_circle.c
@@ -268,9 +268,9 @@ vips_hough_circle_init( VipsHoughCircle *hough_circle )
 }
 
 /**
- * vips_hough_circle:
+ * vips_hough_circle: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/arithmetic/hough_line.c
+++ b/libvips/arithmetic/hough_line.c
@@ -162,9 +162,9 @@ vips_hough_line_init( VipsHoughLine *hough_line )
 }
 
 /**
- * vips_hough_line:
+ * vips_hough_line: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/arithmetic/invert.c
+++ b/libvips/arithmetic/invert.c
@@ -175,9 +175,9 @@ vips_invert_init( VipsInvert *invert )
 }
 
 /**
- * vips_invert:
+ * vips_invert: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * For unsigned formats, this operation calculates (max - @in), eg. (255 -

--- a/libvips/arithmetic/linear.c
+++ b/libvips/arithmetic/linear.c
@@ -438,9 +438,9 @@ vips_linearv( VipsImage *in, VipsImage **out,
 }
 
 /**
- * vips_linear:
+ * vips_linear: (method)
  * @in: image to transform
- * @out: output image
+ * @out: (out): output image
  * @a: (array length=n): array of constants for multiplication
  * @b: (array length=n): array of constants for addition
  * @n: length of constant arrays
@@ -480,9 +480,9 @@ vips_linear( VipsImage *in, VipsImage **out, double *a, double *b, int n, ... )
 }
 
 /**
- * vips_linear1:
+ * vips_linear1: (method)
  * @in: image to transform
- * @out: output image
+ * @out: (out): output image
  * @a: constant for multiplication
  * @b: constant for addition
  * @...: %NULL-terminated list of optional named arguments

--- a/libvips/arithmetic/math.c
+++ b/libvips/arithmetic/math.c
@@ -230,9 +230,9 @@ vips_mathv( VipsImage *in, VipsImage **out, VipsOperationMath math, va_list ap )
 }
 
 /**
- * vips_math:
+ * vips_math: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @math: math operation to perform
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -261,9 +261,9 @@ vips_math( VipsImage *in, VipsImage **out, VipsOperationMath math, ... )
 }
 
 /**
- * vips_sin:
+ * vips_sin: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_MATH_SIN on an image. See vips_math().
@@ -284,9 +284,9 @@ vips_sin( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_cos:
+ * vips_cos: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_MATH_COS on an image. See vips_math().
@@ -307,9 +307,9 @@ vips_cos( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_tan:
+ * vips_tan: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_MATH_TAN on an image. See vips_math().
@@ -330,9 +330,9 @@ vips_tan( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_asin:
+ * vips_asin: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_MATH_ASIN on an image. See vips_math().
@@ -353,9 +353,9 @@ vips_asin( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_acos:
+ * vips_acos: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_MATH_ACOS on an image. See vips_math().
@@ -376,9 +376,9 @@ vips_acos( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_atan:
+ * vips_atan: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_MATH_ATAN on an image. See vips_math().
@@ -399,9 +399,9 @@ vips_atan( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_log:
+ * vips_log: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_MATH_LOG on an image. See vips_math().
@@ -422,9 +422,9 @@ vips_log( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_log10:
+ * vips_log10: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_MATH_LOG10 on an image. See vips_math().
@@ -445,9 +445,9 @@ vips_log10( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_exp:
+ * vips_exp: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_MATH_EXP on an image. See vips_math().
@@ -468,9 +468,9 @@ vips_exp( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_exp10:
+ * vips_exp10: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_MATH_EXP10 on an image. See vips_math().

--- a/libvips/arithmetic/math2.c
+++ b/libvips/arithmetic/math2.c
@@ -225,7 +225,7 @@ vips_math2v( VipsImage *left, VipsImage *right, VipsImage **out,
  * vips_math2:
  * @left: left-hand input #VipsImage
  * @right: right-hand input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @math2: math operation to perform
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -272,7 +272,7 @@ vips_math2( VipsImage *left, VipsImage *right, VipsImage **out,
  * vips_pow:
  * @left: left-hand input #VipsImage
  * @right: right-hand input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_MATH2_POW on a pair of images. See
@@ -297,7 +297,7 @@ vips_pow( VipsImage *left, VipsImage *right, VipsImage **out, ... )
  * vips_wop:
  * @left: left-hand input #VipsImage
  * @right: right-hand input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_MATH2_WOP on a pair of images. See
@@ -441,11 +441,11 @@ vips_math2_constv( VipsImage *in, VipsImage **out,
 }
 
 /**
- * vips_math2_const:
+ * vips_math2_const: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @math2: math operation to perform
- * @c: array of constants 
+ * @c: (array length=n): array of constants
  * @n: number of constants in @c
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -484,10 +484,10 @@ vips_math2_const( VipsImage *in, VipsImage **out,
 }
 
 /**
- * vips_pow_const:
+ * vips_pow_const: (method)
  * @in: left-hand input #VipsImage
- * @out: output #VipsImage
- * @c: array of constants 
+ * @out: (out): output #VipsImage
+ * @c: (array length=n): array of constants
  * @n: number of constants in @c
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -511,10 +511,10 @@ vips_pow_const( VipsImage *in, VipsImage **out, double *c, int n, ... )
 }
 
 /**
- * vips_wop_const:
+ * vips_wop_const: (method)
  * @in: left-hand input #VipsImage
- * @out: output #VipsImage
- * @c: array of constants 
+ * @out: (out): output #VipsImage
+ * @c: (array length=n): array of constants
  * @n: number of constants in @c
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -538,9 +538,9 @@ vips_wop_const( VipsImage *in, VipsImage **out, double *c, int n, ... )
 }
 
 /**
- * vips_math2_const1:
+ * vips_math2_const1: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @math2: math operation to perform
  * @c: constant 
  * @...: %NULL-terminated list of optional named arguments
@@ -565,9 +565,9 @@ vips_math2_const1( VipsImage *in, VipsImage **out,
 }
 
 /**
- * vips_pow_const1:
+ * vips_pow_const1: (method)
  * @in: left-hand input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @c: constant 
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -591,9 +591,9 @@ vips_pow_const1( VipsImage *in, VipsImage **out, double c, ... )
 }
 
 /**
- * vips_wop_const1:
+ * vips_wop_const1: (method)
  * @in: left-hand input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @c: constant 
  * @...: %NULL-terminated list of optional named arguments
  *

--- a/libvips/arithmetic/max.c
+++ b/libvips/arithmetic/max.c
@@ -491,9 +491,9 @@ vips_max_init( VipsMax *max )
 }
 
 /**
- * vips_max:
+ * vips_max: (method)
  * @in: input #VipsImage
- * @out: output pixel maximum
+ * @out: (out): output pixel maximum
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/arithmetic/measure.c
+++ b/libvips/arithmetic/measure.c
@@ -253,9 +253,9 @@ vips_measure_init( VipsMeasure *measure )
 }
 
 /**
- * vips_measure:
+ * vips_measure: (method)
  * @in: image to measure
- * @out: array of measurements
+ * @out: (out): array of measurements
  * @h: patches across chart
  * @v: patches down chart
  * @...: %NULL-terminated list of optional named arguments

--- a/libvips/arithmetic/min.c
+++ b/libvips/arithmetic/min.c
@@ -492,9 +492,9 @@ vips_min_init( VipsMin *min )
 }
 
 /**
- * vips_min:
+ * vips_min: (method)
  * @in: input #VipsImage
- * @out: output pixel minimum
+ * @out: (out): output pixel minimum
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/arithmetic/multiply.c
+++ b/libvips/arithmetic/multiply.c
@@ -186,7 +186,7 @@ vips_multiply_init( VipsMultiply *multiply )
  * vips_multiply:
  * @left: left-hand image
  * @right: right-hand image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * This operation calculates @left * @right and writes the result to @out. 

--- a/libvips/arithmetic/profile.c
+++ b/libvips/arithmetic/profile.c
@@ -316,10 +316,10 @@ vips_profile_init( VipsProfile *profile )
 }
 
 /**
- * vips_profile:
+ * vips_profile: (method)
  * @in: input image
- * @columns: distances from top edge
- * @rows: distances from left edge
+ * @columns: (out): distances from top edge
+ * @rows: (out): distances from left edge
  * @...: %NULL-terminated list of optional named arguments
  *
  * vips_profile() searches inward from the edge of @in and finds the 

--- a/libvips/arithmetic/project.c
+++ b/libvips/arithmetic/project.c
@@ -346,10 +346,10 @@ vips_project_init( VipsProject *project )
 }
 
 /**
- * vips_project:
+ * vips_project: (method)
  * @in: input image
- * @columns: sums of columns
- * @rows: sums of rows
+ * @columns: (out): sums of columns
+ * @rows: (out): sums of rows
  * @...: %NULL-terminated list of optional named arguments
  *
  * Find the horizontal and vertical projections of an image, ie. the sum

--- a/libvips/arithmetic/relational.c
+++ b/libvips/arithmetic/relational.c
@@ -246,7 +246,7 @@ vips_relationalv( VipsImage *left, VipsImage *right, VipsImage **out,
  * vips_relational:
  * @left: left-hand input #VipsImage
  * @right: right-hand input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @relational: relational operation to perform
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -294,7 +294,7 @@ vips_relational( VipsImage *left, VipsImage *right, VipsImage **out,
  * vips_equal:
  * @left: left-hand input #VipsImage
  * @right: right-hand input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_RELATIONAL_EQUAL on a pair of images. See
@@ -320,7 +320,7 @@ vips_equal( VipsImage *left, VipsImage *right, VipsImage **out, ... )
  * vips_notequal:
  * @left: left-hand input #VipsImage
  * @right: right-hand input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_RELATIONAL_NOTEQ on a pair of images. See
@@ -346,7 +346,7 @@ vips_notequal( VipsImage *left, VipsImage *right, VipsImage **out, ... )
  * vips_more:
  * @left: left-hand input #VipsImage
  * @right: right-hand input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_RELATIONAL_MORE on a pair of images. See
@@ -372,7 +372,7 @@ vips_more( VipsImage *left, VipsImage *right, VipsImage **out, ... )
  * vips_moreeq:
  * @left: left-hand input #VipsImage
  * @right: right-hand input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_RELATIONAL_MOREEQ on a pair of images. See
@@ -398,7 +398,7 @@ vips_moreeq( VipsImage *left, VipsImage *right, VipsImage **out, ... )
  * vips_less:
  * @left: left-hand input #VipsImage
  * @right: right-hand input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_RELATIONAL_LESS on a pair of images. See
@@ -424,7 +424,7 @@ vips_less( VipsImage *left, VipsImage *right, VipsImage **out, ... )
  * vips_lesseq:
  * @left: left-hand input #VipsImage
  * @right: right-hand input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_RELATIONAL_LESSEQ on a pair of images. See
@@ -595,11 +595,11 @@ vips_relational_constv( VipsImage *in, VipsImage **out,
 }
 
 /**
- * vips_relational_const:
+ * vips_relational_const: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @relational: relational operation to perform
- * @c: array of constants 
+ * @c: (array length=n): array of constants
  * @n: number of constants in @c
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -634,10 +634,10 @@ vips_relational_const( VipsImage *in, VipsImage **out,
 }
 
 /**
- * vips_equal_const:
+ * vips_equal_const: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
- * @c: array of constants 
+ * @out: (out): output #VipsImage
+ * @c: (array length=n): array of constants
  * @n: number of constants in @c
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -661,10 +661,10 @@ vips_equal_const( VipsImage *in, VipsImage **out, double *c, int n, ... )
 }
 
 /**
- * vips_notequal_const:
+ * vips_notequal_const: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
- * @c: array of constants 
+ * @out: (out): output #VipsImage
+ * @c: (array length=n): array of constants
  * @n: number of constants in @c
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -688,10 +688,10 @@ vips_notequal_const( VipsImage *in, VipsImage **out, double *c, int n, ... )
 }
 
 /**
- * vips_less_const:
+ * vips_less_const: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
- * @c: array of constants 
+ * @out: (out): output #VipsImage
+ * @c: (array length=n): array of constants
  * @n: number of constants in @c
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -715,10 +715,10 @@ vips_less_const( VipsImage *in, VipsImage **out, double *c, int n, ... )
 }
 
 /**
- * vips_lesseq_const:
+ * vips_lesseq_const: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
- * @c: array of constants 
+ * @out: (out): output #VipsImage
+ * @c: (array length=n): array of constants
  * @n: number of constants in @c
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -742,10 +742,10 @@ vips_lesseq_const( VipsImage *in, VipsImage **out, double *c, int n, ... )
 }
 
 /**
- * vips_more_const:
+ * vips_more_const: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
- * @c: array of constants 
+ * @out: (out): output #VipsImage
+ * @c: (array length=n): array of constants
  * @n: number of constants in @c
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -769,10 +769,10 @@ vips_more_const( VipsImage *in, VipsImage **out, double *c, int n, ... )
 }
 
 /**
- * vips_moreeq_const:
+ * vips_moreeq_const: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
- * @c: array of constants 
+ * @out: (out): output #VipsImage
+ * @c: (array length=n): array of constants
  * @n: number of constants in @c
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -796,9 +796,9 @@ vips_moreeq_const( VipsImage *in, VipsImage **out, double *c, int n, ... )
 }
 
 /**
- * vips_relational_const1:
+ * vips_relational_const1: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @relational: relational operation to perform
  * @c: constant 
  * @...: %NULL-terminated list of optional named arguments
@@ -825,9 +825,9 @@ vips_relational_const1( VipsImage *in, VipsImage **out,
 }
 
 /**
- * vips_equal_const1:
+ * vips_equal_const1: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @c: constant 
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -851,9 +851,9 @@ vips_equal_const1( VipsImage *in, VipsImage **out, double c, ... )
 }
 
 /**
- * vips_notequal_const1:
+ * vips_notequal_const1: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @c: constant 
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -877,9 +877,9 @@ vips_notequal_const1( VipsImage *in, VipsImage **out, double c, ... )
 }
 
 /**
- * vips_less_const1:
+ * vips_less_const1: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @c: constant 
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -903,9 +903,9 @@ vips_less_const1( VipsImage *in, VipsImage **out, double c, ... )
 }
 
 /**
- * vips_lesseq_const1:
+ * vips_lesseq_const1: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @c: constant 
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -929,9 +929,9 @@ vips_lesseq_const1( VipsImage *in, VipsImage **out, double c, ... )
 }
 
 /**
- * vips_more_const1:
+ * vips_more_const1: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @c: constant 
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -955,9 +955,9 @@ vips_more_const1( VipsImage *in, VipsImage **out, double c, ... )
 }
 
 /**
- * vips_moreeq_const1:
+ * vips_moreeq_const1: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @c: constant 
  * @...: %NULL-terminated list of optional named arguments
  *

--- a/libvips/arithmetic/remainder.c
+++ b/libvips/arithmetic/remainder.c
@@ -189,7 +189,7 @@ vips_remainder_init( VipsRemainder *remainder )
  * vips_remainder:
  * @left: left-hand input #VipsImage
  * @right: right-hand input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * This operation calculates @left % @right (remainder after integer division) 
@@ -357,10 +357,10 @@ vips_remainder_constv( VipsImage *in, VipsImage **out,
 }
 
 /**
- * vips_remainder_const:
+ * vips_remainder_const: (method)
  * @in: input image
- * @out: output image
- * @c: array of constants 
+ * @out: (out): output image
+ * @c: (array length=n): array of constants
  * @n: number of constants in @c
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -396,9 +396,9 @@ vips_remainder_const( VipsImage *in, VipsImage **out, double *c, int n, ... )
 }
 
 /**
- * vips_remainder_const1:
+ * vips_remainder_const1: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @c: constant 
  * @...: %NULL-terminated list of optional named arguments
  *

--- a/libvips/arithmetic/round.c
+++ b/libvips/arithmetic/round.c
@@ -186,9 +186,9 @@ vips_roundv( VipsImage *in, VipsImage **out,
 }
 
 /**
- * vips_round:
+ * vips_round: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @round: #VipsOperationRound rounding operation to perform
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -218,9 +218,9 @@ vips_round( VipsImage *in, VipsImage **out, VipsOperationRound round, ... )
 }
 
 /**
- * vips_floor:
+ * vips_floor: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Round to an integral value with #VIPS_OPERATION_ROUND_FLOOR. See 
@@ -242,9 +242,9 @@ vips_floor( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_ceil:
+ * vips_ceil: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Round to an integral value with #VIPS_OPERATION_ROUND_CEIL. See 
@@ -266,9 +266,9 @@ vips_ceil( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_rint:
+ * vips_rint: (method)
  * @in: input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Round to an integral value with #VIPS_OPERATION_ROUND_RINT. See 

--- a/libvips/arithmetic/sign.c
+++ b/libvips/arithmetic/sign.c
@@ -162,9 +162,9 @@ vips_sign_init( VipsSign *sign )
 }
 
 /**
- * vips_sign:
+ * vips_sign: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Finds the unit vector in the direction of the pixel value. For non-complex

--- a/libvips/arithmetic/stats.c
+++ b/libvips/arithmetic/stats.c
@@ -429,9 +429,9 @@ vips_stats_init( VipsStats *stats )
 }
 
 /**
- * vips_stats:
+ * vips_stats: (method)
  * @in: image to scan
- * @out: image of statistics
+ * @out: (out): image of statistics
  * @...: %NULL-terminated list of optional named arguments
  *
  * Find many image statistics in a single pass through the data. @out is a

--- a/libvips/arithmetic/subtract.c
+++ b/libvips/arithmetic/subtract.c
@@ -175,7 +175,7 @@ vips_subtract_init( VipsSubtract *subtract )
  * vips_subtract:
  * @in1: input image 
  * @in2: input image 
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * This operation calculates @in1 - @in2 and writes the result to @out. 

--- a/libvips/arithmetic/sum.c
+++ b/libvips/arithmetic/sum.c
@@ -165,8 +165,8 @@ vips_sumv( VipsImage **in, VipsImage **out, int n, va_list ap )
 
 /**
  * vips_sum:
- * @in: array of input images
- * @out: output image
+ * @in: (array length=n): array of input images
+ * @out: (out): output image
  * @n: number of input images
  * @...: %NULL-terminated list of optional named arguments
  *


### PR DESCRIPTION
PR adds `(out)` for out parameters. Most functions take a single Image input and those have been marked as `(method)`. Functions that take two Image inputs, e.g. add, remain as functions, rather than methods. There are also a few `(array length=n)` additions.