### PR TITLE
Update GObject annotations for libvips/conversion directory

### DIFF
--- a/libvips/conversion/arrayjoin.c
+++ b/libvips/conversion/arrayjoin.c
@@ -384,7 +384,7 @@ vips_arrayjoinv( VipsImage **in, VipsImage **out, int n, va_list ap )
 /**
  * vips_arrayjoin:
  * @in: (array length=n) (transfer none): array of input images
- * @out: output image
+ * @out: (out): output image
  * @n: number of input images
  * @...: %NULL-terminated list of optional named arguments
  *

--- a/libvips/conversion/autorot.c
+++ b/libvips/conversion/autorot.c
@@ -125,7 +125,7 @@ vips_autorot_remove_angle_sub( VipsImage *image,
 }
 
 /**
- * vips_autorot_remove_angle:
+ * vips_autorot_remove_angle: (method)
  * @image: image to remove orientation from
  *
  * Remove the orientation tag on @image. Also remove any exif orientation tags. 
@@ -195,9 +195,9 @@ vips_autorot_init( VipsAutorot *autorot )
 }
 
 /**
- * vips_autorot:
+ * vips_autorot: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/conversion/bandbool.c
+++ b/libvips/conversion/bandbool.c
@@ -239,9 +239,9 @@ vips_bandboolv( VipsImage *in, VipsImage **out,
 }
 
 /**
- * vips_bandbool:
+ * vips_bandbool: (method)
  * @in: left-hand input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @boolean: boolean operation to perform
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -279,9 +279,9 @@ vips_bandbool( VipsImage *in, VipsImage **out,
 }
 
 /**
- * vips_bandand:
+ * vips_bandand: (method)
  * @in: left-hand input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_BOOLEAN_AND on an image. See
@@ -303,9 +303,9 @@ vips_bandand( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_bandor:
+ * vips_bandor: (method)
  * @in: left-hand input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_BOOLEAN_OR on an image. See
@@ -327,9 +327,9 @@ vips_bandor( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_bandeor:
+ * vips_bandeor: (method)
  * @in: left-hand input #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform #VIPS_OPERATION_BOOLEAN_EOR on an image. See

--- a/libvips/conversion/bandfold.c
+++ b/libvips/conversion/bandfold.c
@@ -179,9 +179,9 @@ vips_bandfold_init( VipsBandfold *bandfold )
 }
 
 /**
- * vips_bandfold:
+ * vips_bandfold: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/conversion/bandjoin.c
+++ b/libvips/conversion/bandjoin.c
@@ -428,8 +428,8 @@ vips_bandjoin_constv( VipsImage *in, VipsImage **out,
 }
 
 /**
- * vips_bandjoin_const:
- * @in: (array length=n) (transfer none): array of input images
+ * vips_bandjoin_const: (method)
+ * @in: input image
  * @out: (out): output image
  * @c: (array length=n): array of constants to append
  * @n: number of constants

--- a/libvips/conversion/bandjoin.c
+++ b/libvips/conversion/bandjoin.c
@@ -204,7 +204,7 @@ vips_bandjoinv( VipsImage **in, VipsImage **out, int n, va_list ap )
 /**
  * vips_bandjoin:
  * @in: (array length=n) (transfer none): array of input images
- * @out: output image
+ * @out: (out): output image
  * @n: number of input images
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -243,7 +243,7 @@ vips_bandjoin( VipsImage **in, VipsImage **out, int n, ... )
  * vips_bandjoin2:
  * @in1: first input image
  * @in2: second input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Join a pair of images together, bandwise. See vips_bandjoin().
@@ -430,7 +430,7 @@ vips_bandjoin_constv( VipsImage *in, VipsImage **out,
 /**
  * vips_bandjoin_const:
  * @in: (array length=n) (transfer none): array of input images
- * @out: output image
+ * @out: (out): output image
  * @c: (array length=n): array of constants to append
  * @n: number of constants
  * @...: %NULL-terminated list of optional named arguments
@@ -455,9 +455,9 @@ vips_bandjoin_const( VipsImage *in, VipsImage **out, double *c, int n, ... )
 }
 
 /**
- * vips_bandjoin_const1:
+ * vips_bandjoin_const1: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @c: constant to append
  * @...: %NULL-terminated list of optional named arguments
  *

--- a/libvips/conversion/bandmean.c
+++ b/libvips/conversion/bandmean.c
@@ -207,9 +207,9 @@ vips_bandmean_init( VipsBandmean *bandmean )
 }
 
 /**
- * vips_bandmean:
+ * vips_bandmean: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * This operation writes a one-band image where each pixel is the average of 

--- a/libvips/conversion/bandrank.c
+++ b/libvips/conversion/bandrank.c
@@ -279,8 +279,8 @@ vips_bandrankv( VipsImage **in, VipsImage **out, int n, va_list ap )
 
 /**
  * vips_bandrank:
- * @in: array of input images
- * @out: output image
+ * @in: (array length=n): array of input images
+ * @out: (out): output image
  * @n: number of input images
  * @...: %NULL-terminated list of optional named arguments
  *

--- a/libvips/conversion/bandunfold.c
+++ b/libvips/conversion/bandunfold.c
@@ -182,9 +182,9 @@ vips_bandunfold_init( VipsBandunfold *bandunfold )
 }
 
 /**
- * vips_bandunfold:
+ * vips_bandunfold: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/conversion/byteswap.c
+++ b/libvips/conversion/byteswap.c
@@ -216,9 +216,9 @@ vips_byteswap_init( VipsByteswap *byteswap )
 }
 
 /**
- * vips_byteswap:
+ * vips_byteswap: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Swap the byte order in an image. 

--- a/libvips/conversion/cache.c
+++ b/libvips/conversion/cache.c
@@ -137,9 +137,9 @@ vips_cache_init( VipsCache *cache )
 }
 
 /**
- * vips_cache:
+ * vips_cache: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/conversion/cast.c
+++ b/libvips/conversion/cast.c
@@ -577,9 +577,9 @@ vips_castv( VipsImage *in, VipsImage **out, VipsBandFormat format, va_list ap )
 }
 
 /**
- * vips_cast:
+ * vips_cast: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @format: format to convert to
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -616,9 +616,9 @@ vips_cast( VipsImage *in, VipsImage **out, VipsBandFormat format, ... )
 }
 
 /**
- * vips_cast_uchar:
+ * vips_cast_uchar: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Convert @in to #VIPS_FORMAT_UCHAR. See vips_cast(). 
@@ -639,9 +639,9 @@ vips_cast_uchar( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_cast_char:
+ * vips_cast_char: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Convert @in to #VIPS_FORMAT_CHAR. See vips_cast(). 
@@ -662,9 +662,9 @@ vips_cast_char( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_cast_ushort:
+ * vips_cast_ushort: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Convert @in to #VIPS_FORMAT_USHORT. See vips_cast(). 
@@ -685,9 +685,9 @@ vips_cast_ushort( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_cast_short:
+ * vips_cast_short: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Convert @in to #VIPS_FORMAT_SHORT. See vips_cast(). 
@@ -708,9 +708,9 @@ vips_cast_short( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_cast_uint:
+ * vips_cast_uint: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Convert @in to #VIPS_FORMAT_UINT. See vips_cast(). 
@@ -731,9 +731,9 @@ vips_cast_uint( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_cast_int:
+ * vips_cast_int: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Convert @in to #VIPS_FORMAT_INT. See vips_cast(). 
@@ -754,9 +754,9 @@ vips_cast_int( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_cast_float:
+ * vips_cast_float: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Convert @in to #VIPS_FORMAT_FLOAT. See vips_cast(). 
@@ -777,9 +777,9 @@ vips_cast_float( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_cast_double:
+ * vips_cast_double: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Convert @in to #VIPS_FORMAT_DOUBLE. See vips_cast(). 
@@ -800,9 +800,9 @@ vips_cast_double( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_cast_complex:
+ * vips_cast_complex: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Convert @in to #VIPS_FORMAT_COMPLEX. See vips_cast(). 
@@ -823,9 +823,9 @@ vips_cast_complex( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_cast_dpcomplex:
+ * vips_cast_dpcomplex: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Convert @in to #VIPS_FORMAT_DPCOMPLEX. See vips_cast(). 

--- a/libvips/conversion/copy.c
+++ b/libvips/conversion/copy.c
@@ -359,9 +359,9 @@ vips_copy_init( VipsCopy *copy )
 }
 
 /**
- * vips_copy:
+ * vips_copy: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:
@@ -403,9 +403,9 @@ vips_copy( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_copy_file:
+ * vips_copy_file: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * A simple convenience function to copy an image to a file, then copy 

--- a/libvips/conversion/embed.c
+++ b/libvips/conversion/embed.c
@@ -618,9 +618,9 @@ vips_embed_init( VipsEmbed *embed )
 }
 
 /**
- * vips_embed:
+ * vips_embed: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @x: place @in at this x position in @out
  * @y: place @in at this y position in @out
  * @width: @out should be this many pixels across

--- a/libvips/conversion/extract.c
+++ b/libvips/conversion/extract.c
@@ -232,9 +232,9 @@ vips_extract_area_init( VipsExtractArea *extract )
 }
 
 /**
- * vips_extract_area:
+ * vips_extract_area: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @left: left edge of area to extract
  * @top: top edge of area to extract
  * @width: width of area to extract
@@ -291,9 +291,9 @@ vips_crop_get_type( void )
 }
 
 /**
- * vips_crop:
+ * vips_crop: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @left: left edge of area to extract
  * @top: top edge of area to extract
  * @width: width of area to extract
@@ -442,9 +442,9 @@ vips_extract_band_init( VipsExtractBand *extract )
 }
 
 /**
- * vips_extract_band:
+ * vips_extract_band: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @band: band to extract
  * @...: %NULL-terminated list of optional named arguments
  *

--- a/libvips/conversion/falsecolour.c
+++ b/libvips/conversion/falsecolour.c
@@ -391,9 +391,9 @@ vips_falsecolour_init( VipsFalsecolour *falsecolour )
 }
 
 /**
- * vips_falsecolour:
+ * vips_falsecolour: (method)
  * @in: input image 
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Force @in to 1 band, 8-bit, then transform to 

--- a/libvips/conversion/flatten.c
+++ b/libvips/conversion/flatten.c
@@ -412,9 +412,9 @@ vips_flatten_init( VipsFlatten *flatten )
 }
 
 /**
- * vips_flatten:
+ * vips_flatten: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/conversion/flip.c
+++ b/libvips/conversion/flip.c
@@ -256,9 +256,9 @@ vips_flip_init( VipsFlip *flip )
 }
 
 /**
- * vips_flip:
+ * vips_flip: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @direction: flip horizontally or vertically
  * @...: %NULL-terminated list of optional named arguments
  *

--- a/libvips/conversion/gamma.c
+++ b/libvips/conversion/gamma.c
@@ -161,9 +161,9 @@ vips_gamma_init( VipsGamma *gamma )
 }
 
 /**
- * vips_gamma:
+ * vips_gamma: (method)
  * @in: input image 
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/conversion/grid.c
+++ b/libvips/conversion/grid.c
@@ -233,9 +233,9 @@ vips_grid_init( VipsGrid *grid )
 }
 
 /**
- * vips_grid:
+ * vips_grid: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @tile_height: chop into tiles this high
  * @across: tiles across
  * @down: tiles down

--- a/libvips/conversion/ifthenelse.c
+++ b/libvips/conversion/ifthenelse.c
@@ -515,7 +515,7 @@ vips_ifthenelse_init( VipsIfthenelse *ifthenelse )
  * @cond: condition #VipsImage
  * @in1: then #VipsImage
  * @in2: else #VipsImage
- * @out: output #VipsImage
+ * @out: (out): output #VipsImage
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/conversion/insert.c
+++ b/libvips/conversion/insert.c
@@ -556,10 +556,10 @@ vips_insert_init( VipsInsert *insert )
 }
 
 /**
- * vips_insert:
+ * vips_insert: (method)
  * @main: big image
  * @sub: small image
- * @out: output image
+ * @out: (out): output image
  * @x: left position of @sub
  * @y: top position of @sub
  * @...: %NULL-terminated list of optional named arguments

--- a/libvips/conversion/join.c
+++ b/libvips/conversion/join.c
@@ -295,7 +295,7 @@ vips_join_init( VipsJoin *join )
  * vips_join:
  * @in1: first input image 
  * @in2: second input image 
- * @out: output image
+ * @out: (out): output image
  * @direction: join horizontally or vertically
  * @...: %NULL-terminated list of optional named arguments
  *

--- a/libvips/conversion/msb.c
+++ b/libvips/conversion/msb.c
@@ -262,9 +262,9 @@ vips_msb_init( VipsMsb *msb )
 }
 
 /**
- * vips_msb:
+ * vips_msb: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/conversion/premultiply.c
+++ b/libvips/conversion/premultiply.c
@@ -276,9 +276,9 @@ vips_premultiply_init( VipsPremultiply *premultiply )
 }
 
 /**
- * vips_premultiply:
+ * vips_premultiply: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/conversion/recomb.c
+++ b/libvips/conversion/recomb.c
@@ -222,9 +222,9 @@ vips_recomb_init( VipsRecomb *recomb )
 }
 
 /** 
- * vips_recomb:
+ * vips_recomb: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @m: recombination matrix
  * @...: %NULL-terminated list of optional named arguments
  *

--- a/libvips/conversion/replicate.c
+++ b/libvips/conversion/replicate.c
@@ -220,9 +220,9 @@ vips_replicate_init( VipsReplicate *replicate )
 }
 
 /**
- * vips_replicate:
+ * vips_replicate: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @across: repeat input this many times across
  * @down: repeat input this many times down
  * @...: %NULL-terminated list of optional named arguments

--- a/libvips/conversion/rot.c
+++ b/libvips/conversion/rot.c
@@ -383,9 +383,9 @@ vips_rotv( VipsImage *in, VipsImage **out, VipsAngle angle, va_list ap )
 }
 
 /**
- * vips_rot:
+ * vips_rot: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @angle: rotation angle
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -437,9 +437,9 @@ vips_rot90( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_rot180:
+ * vips_rot180: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Rotate @in by 180 degress. A convenience function over vips_rot().
@@ -462,9 +462,9 @@ vips_rot180( VipsImage *in, VipsImage **out, ... )
 }
 
 /**
- * vips_rot270:
+ * vips_rot270: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Rotate @in by 270 degress clockwise. A convenience function over vips_rot().

--- a/libvips/conversion/rot45.c
+++ b/libvips/conversion/rot45.c
@@ -284,9 +284,9 @@ vips_rot45_init( VipsRot45 *rot45 )
 }
 
 /**
- * vips_rot45:
+ * vips_rot45: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/conversion/scale.c
+++ b/libvips/conversion/scale.c
@@ -176,9 +176,9 @@ vips_scale_init( VipsScale *scale )
 }
 
 /**
- * vips_scale:
+ * vips_scale: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/conversion/sequential.c
+++ b/libvips/conversion/sequential.c
@@ -265,9 +265,9 @@ vips_sequential_init( VipsSequential *sequential )
 }
 
 /**
- * vips_sequential:
+ * vips_sequential: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/conversion/smartcrop.c
+++ b/libvips/conversion/smartcrop.c
@@ -417,9 +417,9 @@ vips_smartcrop_init( VipsSmartcrop *smartcrop )
 }
 
 /**
- * vips_smartcrop:
+ * vips_smartcrop: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @width: width of area to extract
  * @height: height of area to extract
  * @...: %NULL-terminated list of optional named arguments

--- a/libvips/conversion/subsample.c
+++ b/libvips/conversion/subsample.c
@@ -300,9 +300,9 @@ vips_subsample_init( VipsSubsample *subsample )
 }
 
 /**
- * vips_subsample:
+ * vips_subsample: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @xfac: horizontal shrink factor
  * @yfac: vertical shrink factor
  * @...: %NULL-terminated list of optional named arguments

--- a/libvips/conversion/tilecache.c
+++ b/libvips/conversion/tilecache.c
@@ -819,9 +819,9 @@ vips_tile_cache_init( VipsTileCache *cache )
 }
 
 /**
- * vips_tilecache:
+ * vips_tilecache: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:
@@ -988,9 +988,9 @@ vips_line_cache_init( VipsLineCache *cache )
 }
 
 /**
- * vips_linecache:
+ * vips_linecache: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/conversion/unpremultiply.c
+++ b/libvips/conversion/unpremultiply.c
@@ -286,9 +286,9 @@ vips_unpremultiply_init( VipsUnpremultiply *unpremultiply )
 }
 
 /**
- * vips_unpremultiply:
+ * vips_unpremultiply: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/conversion/wrap.c
+++ b/libvips/conversion/wrap.c
@@ -143,9 +143,9 @@ vips_wrap_init( VipsWrap *wrap )
 }
 
 /**
- * vips_wrap:
+ * vips_wrap: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/conversion/zoom.c
+++ b/libvips/conversion/zoom.c
@@ -402,9 +402,9 @@ vips_zoom_init( VipsZoom *zoom )
 }
 
 /**
- * vips_zoom:
+ * vips_zoom: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @xfac: horizontal scale factor
  * @yfac: vertical scale factor
  * @...: %NULL-terminated list of optional named arguments


### PR DESCRIPTION
Further work on #741 

Two queries came up when looking through `libvips/conversion`:

 1. Should `vips_bandjoin_const()` in `bandjoin.c` be `**in` instead of `*in` ? The docs state it is an array.

 2. The annotation for `vips_bandrank( VipsImage **in, VipsImage **out, int n, ... )` in `bandrank.c` is ` @in: (array length=n): array of input images`. Should this include `(tansfer none)`, similar to `vips_arrayjoin()` ?