### PR TITLE
Update GObject introspection annotations for libvips/foreign directory

### DIFF
--- a/libvips/foreign/analyzeload.c
+++ b/libvips/foreign/analyzeload.c
@@ -149,7 +149,7 @@ vips_foreign_load_analyze_init( VipsForeignLoadAnalyze *analyze )
 /**
  * vips_analyzeload:
  * @filename: file to load
- * @out: decompressed image
+ * @out: (out): decompressed image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Load an Analyze 6.0 file. If @filename is "fred.img", this will look for

--- a/libvips/foreign/csvload.c
+++ b/libvips/foreign/csvload.c
@@ -184,7 +184,7 @@ vips_foreign_load_csv_init( VipsForeignLoadCsv *csv )
 /**
  * vips_csvload:
  * @filename: file to load
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/foreign/csvsave.c
+++ b/libvips/foreign/csvsave.c
@@ -121,7 +121,7 @@ vips_foreign_save_csv_init( VipsForeignSaveCsv *csv )
 }
 
 /**
- * vips_csvsave:
+ * vips_csvsave: (method)
  * @in: image to save 
  * @filename: file to write to
  * @...: %NULL-terminated list of optional named arguments

--- a/libvips/foreign/dzsave.c
+++ b/libvips/foreign/dzsave.c
@@ -2279,7 +2279,7 @@ vips_foreign_save_dz_buffer_init( VipsForeignSaveDzBuffer *buffer )
 #endif /*HAVE_GSF*/
 
 /**
- * vips_dzsave:
+ * vips_dzsave: (method)
  * @in: image to save 
  * @name: name to save to 
  * @...: %NULL-terminated list of optional named arguments
@@ -2353,10 +2353,10 @@ vips_dzsave( VipsImage *in, const char *name, ... )
 }
 
 /**
- * vips_dzsave_buffer:
+ * vips_dzsave_buffer: (method)
  * @in: image to save 
- * @buf: return output buffer here
- * @len: return output length here
+ * @buf: (array length=len) (element-type guint8): return output buffer here
+ * @len: (type gsize): return output length here
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/foreign/fitsload.c
+++ b/libvips/foreign/fitsload.c
@@ -137,7 +137,7 @@ vips_foreign_load_fits_init( VipsForeignLoadFits *fits )
 /**
  * vips_fitsload:
  * @filename: file to load
- * @out: decompressed image
+ * @out: (out): decompressed image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Read a FITS image file into a VIPS image. 

--- a/libvips/foreign/fitssave.c
+++ b/libvips/foreign/fitssave.c
@@ -150,7 +150,7 @@ vips_foreign_save_fits_init( VipsForeignSaveFits *fits )
 #endif /*HAVE_CFITSIO*/
 
 /**
- * vips_fitssave:
+ * vips_fitssave: (method)
  * @in: image to save 
  * @filename: file to write to 
  * @...: %NULL-terminated list of optional named arguments

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -584,7 +584,7 @@ vips_foreign_find_load_buffer_sub( VipsForeignLoadClass *load_class,
  * vips_foreign_find_load_buffer:
  * @data: (array length=size) (element-type guint8) (transfer none): start of 
  * memory buffer
- * @size: number of bytes in @data
+ * @size: (type gsize): number of bytes in @data
  *
  * Searches for an operation you could use to load a memory buffer. To see the
  * range of buffer loaders supported by your vips, try something like:
@@ -642,8 +642,8 @@ vips_foreign_is_a( const char *loader, const char *filename )
 /**
  * vips_foreign_is_a_buffer:
  * @loader: name of loader to use for test
- * @data: pointer to the buffer to test
- * @size: size of the buffer to test
+ * @data: (array length=size) (element-type guint8): pointer to the buffer to test
+ * @size: (type gsize): size of the buffer to test
  *
  * Return %TRUE if @data can be loaded by @loader. @loader is something
  * like "tiffload_buffer" or "VipsForeignLoadTiffBuffer".
@@ -1052,7 +1052,7 @@ vips_foreign_load_init( VipsForeignLoad *load )
  */
 
 /**
- * vips_foreign_load_invalidate:
+ * vips_foreign_load_invalidate: (method)
  * @image: image to invalidate
  *
  * Loaders can call this on the image they are making if they see a read error

--- a/libvips/foreign/gifload.c
+++ b/libvips/foreign/gifload.c
@@ -1004,7 +1004,7 @@ vips_foreign_load_gif_buffer_init( VipsForeignLoadGifBuffer *buffer )
 /**
  * vips_gifload:
  * @filename: file to load
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:
@@ -1043,9 +1043,9 @@ vips_gifload( const char *filename, VipsImage **out, ... )
 
 /**
  * vips_gifload_buffer:
- * @buf: memory area to load
- * @len: size of memory area
- * @out: image to write
+ * @buf: (array length=len) (element-type guint8): memory area to load
+ * @len: (type gsize): size of memory area
+ * @out: (out): image to write
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/foreign/jpegload.c
+++ b/libvips/foreign/jpegload.c
@@ -322,7 +322,7 @@ vips_foreign_load_jpeg_buffer_init( VipsForeignLoadJpegBuffer *buffer )
 /**
  * vips_jpegload:
  * @filename: file to load
- * @out: decompressed image
+ * @out: (out): decompressed image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:
@@ -398,9 +398,9 @@ vips_jpegload( const char *filename, VipsImage **out, ... )
 
 /**
  * vips_jpegload_buffer:
- * @buf: memory area to load
- * @len: size of memory area
- * @out: image to write
+ * @buf: (array length=len) (element-type guint8): memory area to load
+ * @len: (type gsize): size of memory area
+ * @out: (out): image to write
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/foreign/jpegsave.c
+++ b/libvips/foreign/jpegsave.c
@@ -412,7 +412,7 @@ vips_foreign_save_jpeg_mime_init( VipsForeignSaveJpegMime *mime )
 #endif /*HAVE_JPEG*/
 
 /**
- * vips_jpegsave:
+ * vips_jpegsave: (method)
  * @in: image to save 
  * @filename: file to write to 
  * @...: %NULL-terminated list of optional named arguments
@@ -526,10 +526,10 @@ vips_jpegsave( VipsImage *in, const char *filename, ... )
 }
 
 /**
- * vips_jpegsave_buffer:
+ * vips_jpegsave_buffer: (method)
  * @in: image to save 
- * @buf: return output buffer here
- * @len: return output length here
+ * @buf: (array length=len) (element-type guint8): return output buffer here
+ * @len: (type gsize): return output length here
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:
@@ -584,7 +584,7 @@ vips_jpegsave_buffer( VipsImage *in, void **buf, size_t *len, ... )
 }
 
 /**
- * vips_jpegsave_mime:
+ * vips_jpegsave_mime: (method)
  * @in: image to save 
  * @...: %NULL-terminated list of optional named arguments
  *

--- a/libvips/foreign/magickload.c
+++ b/libvips/foreign/magickload.c
@@ -329,7 +329,7 @@ vips_foreign_load_magick_buffer_init( VipsForeignLoadMagickBuffer *buffer )
 /**
  * vips_magickload:
  * @filename: file to load
- * @out: decompressed image
+ * @out: (out): decompressed image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:
@@ -376,9 +376,9 @@ vips_magickload( const char *filename, VipsImage **out, ... )
 
 /**
  * vips_magickload_buffer:
- * @buf: memory area to load
+ * @buf: (array length=len) (element-type guint8): memory area to load
  * @len: size of memory area
- * @out: image to write
+ * @out: (out): image to write
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/foreign/matload.c
+++ b/libvips/foreign/matload.c
@@ -147,7 +147,7 @@ vips_foreign_load_mat_init( VipsForeignLoadMat *mat )
 /**
  * vips_matload:
  * @filename: file to load
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Read a Matlab save file into a VIPS image. 

--- a/libvips/foreign/matrixload.c
+++ b/libvips/foreign/matrixload.c
@@ -165,7 +165,7 @@ vips_foreign_load_matrix_init( VipsForeignLoadMatrix *matrix )
 /**
  * vips_matrixload:
  * @filename: file to load
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Reads a matrix from a file.

--- a/libvips/foreign/matrixsave.c
+++ b/libvips/foreign/matrixsave.c
@@ -131,7 +131,7 @@ vips_foreign_save_matrix_init( VipsForeignSaveMatrix *matrix )
 }
 
 /**
- * vips_matrixsave:
+ * vips_matrixsave: (method)
  * @in: image to save 
  * @filename: file to write to
  * @...: %NULL-terminated list of optional named arguments
@@ -204,7 +204,7 @@ vips_foreign_print_matrix_init( VipsForeignPrintMatrix *matrix )
 }
 
 /**
- * vips_matrixprint:
+ * vips_matrixprint: (method)
  * @in: image to print 
  * @...: %NULL-terminated list of optional named arguments
  *

--- a/libvips/foreign/openexrload.c
+++ b/libvips/foreign/openexrload.c
@@ -158,7 +158,7 @@ vips_foreign_load_openexr_init( VipsForeignLoadOpenexr *openexr )
 /**
  * vips_openexrload:
  * @filename: file to load
- * @out: decompressed image
+ * @out: (out): decompressed image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Read a OpenEXR file into a VIPS image. 

--- a/libvips/foreign/openslideload.c
+++ b/libvips/foreign/openslideload.c
@@ -222,7 +222,7 @@ vips_foreign_load_openslide_init( VipsForeignLoadOpenslide *openslide )
 /**
  * vips_openslideload:
  * @filename: file to load
- * @out: decompressed image
+ * @out: (out): decompressed image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/foreign/pdfload.c
+++ b/libvips/foreign/pdfload.c
@@ -661,7 +661,7 @@ vips_foreign_load_pdf_buffer_init( VipsForeignLoadPdfBuffer *buffer )
 /**
  * vips_pdfload:
  * @filename: file to load
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:
@@ -726,9 +726,9 @@ vips_pdfload( const char *filename, VipsImage **out, ... )
 
 /**
  * vips_pdfload_buffer:
- * @buf: memory area to load
- * @len: size of memory area
- * @out: image to write
+ * @buf: (array length=len) (element-type guint8): memory area to load
+ * @len: (type gsize): size of memory area
+ * @out: (out): image to write
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/foreign/pngload.c
+++ b/libvips/foreign/pngload.c
@@ -244,7 +244,7 @@ vips_foreign_load_png_buffer_init( VipsForeignLoadPngBuffer *buffer )
 /**
  * vips_pngload:
  * @filename: file to load
- * @out: decompressed image
+ * @out: (out): decompressed image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Read a PNG file into a VIPS image. It can read all png images, including 8-
@@ -271,9 +271,9 @@ vips_pngload( const char *filename, VipsImage **out, ... )
 
 /**
  * vips_pngload_buffer:
- * @buf: memory area to load
- * @len: size of memory area
- * @out: image to write
+ * @buf: (array length=len) (element-type guint8): memory area to load
+ * @len: (type gsize): size of memory area
+ * @out: (out): image to write
  * @...: %NULL-terminated list of optional named arguments
  *
  * Read a PNG-formatted memory block into a VIPS image. It can read all png 

--- a/libvips/foreign/pngsave.c
+++ b/libvips/foreign/pngsave.c
@@ -267,7 +267,7 @@ vips_foreign_save_png_buffer_init( VipsForeignSavePngBuffer *buffer )
 #endif /*HAVE_PNG*/
 
 /**
- * vips_pngsave:
+ * vips_pngsave: (method)
  * @in: image to save 
  * @filename: file to write to 
  * @...: %NULL-terminated list of optional named arguments
@@ -322,10 +322,10 @@ vips_pngsave( VipsImage *in, const char *filename, ... )
 }
 
 /**
- * vips_pngsave_buffer:
+ * vips_pngsave_buffer: (method)
  * @in: image to save 
- * @buf: return output buffer here
- * @len: return output length here
+ * @buf: (array length=len) (element-type guint8): return output buffer here
+ * @len: (type gsize): return output length here
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/foreign/ppmload.c
+++ b/libvips/foreign/ppmload.c
@@ -149,7 +149,7 @@ vips_foreign_load_ppm_init( VipsForeignLoadPpm *ppm )
 /**
  * vips_ppmload:
  * @filename: file to load
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Read a PPM/PBM/PGM/PFM file into a VIPS image. 

--- a/libvips/foreign/ppmsave.c
+++ b/libvips/foreign/ppmsave.c
@@ -149,7 +149,7 @@ vips_foreign_save_ppm_init( VipsForeignSavePpm *ppm )
 #endif /*HAVE_PPM*/
 
 /**
- * vips_ppmsave:
+ * vips_ppmsave: (method)
  * @in: image to save 
  * @filename: file to write to
  * @...: %NULL-terminated list of optional named arguments

--- a/libvips/foreign/radload.c
+++ b/libvips/foreign/radload.c
@@ -151,7 +151,7 @@ vips_foreign_load_rad_init( VipsForeignLoadRad *rad )
 /**
  * vips_radload:
  * @filename: file to load
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Read a Radiance (HDR) file into a VIPS image. 

--- a/libvips/foreign/radsave.c
+++ b/libvips/foreign/radsave.c
@@ -229,7 +229,7 @@ vips_foreign_save_rad_buffer_init( VipsForeignSaveRadBuffer *buffer )
 #endif /*HAVE_RADIANCE*/
 
 /**
- * vips_radsave:
+ * vips_radsave: (method)
  * @in: image to save 
  * @filename: file to write to
  * @...: %NULL-terminated list of optional named arguments
@@ -256,10 +256,10 @@ vips_radsave( VipsImage *in, const char *filename, ... )
 }
 
 /**
- * vips_radsave_buffer:
+ * vips_radsave_buffer: (method)
  * @in: image to save 
- * @buf: return output buffer here
- * @len: return output length here
+ * @buf: (array length=len) (element-type guint8): return output buffer here
+ * @len: (type gsize): return output length here
  * @...: %NULL-terminated list of optional named arguments
  *
  * As vips_radsave(), but save to a memory buffer. 

--- a/libvips/foreign/rawload.c
+++ b/libvips/foreign/rawload.c
@@ -157,7 +157,7 @@ vips_foreign_load_raw_init( VipsForeignLoadRaw *raw )
 /**
  * vips_rawload:
  * @filename: file to load
- * @out: output image
+ * @out: (out): output image
  * @width: width of image in pixels
  * @height: height of image in pixels
  * @bands: number of image bands

--- a/libvips/foreign/rawsave.c
+++ b/libvips/foreign/rawsave.c
@@ -155,7 +155,7 @@ vips_foreign_save_raw_init( VipsForeignSaveRaw *raw )
 }
 
 /**
- * vips_rawsave:
+ * vips_rawsave: (method)
  * @in: image to save 
  * @filename: file to write to
  * @...: %NULL-terminated list of optional named arguments
@@ -261,7 +261,7 @@ vips_foreign_save_raw_fd_init( VipsForeignSaveRawFd *fd )
 }
 
 /**
- * vips_rawsave_fd:
+ * vips_rawsave_fd: (method)
  * @in: image to save 
  * @fd: file to write to
  * @...: %NULL-terminated list of optional named arguments

--- a/libvips/foreign/svgload.c
+++ b/libvips/foreign/svgload.c
@@ -579,7 +579,7 @@ vips_foreign_load_svg_buffer_init( VipsForeignLoadSvgBuffer *buffer )
 /**
  * vips_svgload:
  * @filename: file to load
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:
@@ -615,9 +615,9 @@ vips_svgload( const char *filename, VipsImage **out, ... )
 
 /**
  * vips_svgload_buffer:
- * @buf: memory area to load
- * @len: size of memory area
- * @out: image to write
+ * @buf: (array length=len) (element-type guint8): memory area to load
+ * @len: (type gsize): size of memory area
+ * @out: (out): image to write
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/foreign/tiffload.c
+++ b/libvips/foreign/tiffload.c
@@ -326,7 +326,7 @@ vips_foreign_load_tiff_buffer_init( VipsForeignLoadTiffBuffer *buffer )
 /**
  * vips_tiffload:
  * @filename: file to load
- * @out: decompressed image
+ * @out: (out): decompressed image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:
@@ -385,9 +385,9 @@ vips_tiffload( const char *filename, VipsImage **out, ... )
 
 /**
  * vips_tiffload_buffer:
- * @buf: memory area to load
- * @len: size of memory area
- * @out: image to write
+ * @buf: (array length=len) (element-type guint8): memory area to load
+ * @len: (type gsize): size of memory area
+ * @out: (out): image to write
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/foreign/tiffsave.c
+++ b/libvips/foreign/tiffsave.c
@@ -449,7 +449,7 @@ vips_foreign_save_tiff_buffer_init( VipsForeignSaveTiffBuffer *buffer )
 #endif /*HAVE_TIFF*/
 
 /**
- * vips_tiffsave:
+ * vips_tiffsave: (method)
  * @in: image to save 
  * @filename: file to write to 
  * @...: %NULL-terminated list of optional named arguments
@@ -564,10 +564,10 @@ vips_tiffsave( VipsImage *in, const char *filename, ... )
 }
 
 /**
- * vips_tiffsave_buffer:
+ * vips_tiffsave_buffer: (method)
  * @in: image to save 
- * @buf: return output buffer here
- * @len: return output length here
+ * @buf: (array length=len) (element-type guint8): return output buffer here
+ * @len: (type gsize): return output length here
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/foreign/vipsload.c
+++ b/libvips/foreign/vipsload.c
@@ -150,7 +150,7 @@ vips_foreign_load_vips_init( VipsForeignLoadVips *vips )
 /**
  * vips_vipsload:
  * @filename: file to load
- * @out: decompressed image
+ * @out: (out): decompressed image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Read in a vips image. 

--- a/libvips/foreign/vipssave.c
+++ b/libvips/foreign/vipssave.c
@@ -124,7 +124,7 @@ vips_foreign_save_vips_init( VipsForeignSaveVips *vips )
 }
 
 /**
- * vips_vipssave:
+ * vips_vipssave: (method)
  * @in: image to save 
  * @filename: file to write to 
  * @...: %NULL-terminated list of optional named arguments

--- a/libvips/foreign/webpload.c
+++ b/libvips/foreign/webpload.c
@@ -282,7 +282,7 @@ vips_foreign_load_webp_buffer_init( VipsForeignLoadWebpBuffer *buffer )
 /**
  * vips_webpload:
  * @filename: file to load
- * @out: decompressed image
+ * @out: (out): decompressed image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:
@@ -315,9 +315,9 @@ vips_webpload( const char *filename, VipsImage **out, ... )
 
 /**
  * vips_webpload_buffer:
- * @buf: memory area to load
- * @len: size of memory area
- * @out: image to write
+ * @buf: (array length=len) (element-type guint8): memory area to load
+ * @len: (type gsize): size of memory area
+ * @out: (out): image to write
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/foreign/webpsave.c
+++ b/libvips/foreign/webpsave.c
@@ -356,7 +356,7 @@ vips_foreign_save_webp_mime_init( VipsForeignSaveWebpMime *mime )
 #endif /*HAVE_LIBWEBP*/
 
 /**
- * vips_webpsave:
+ * vips_webpsave: (method)
  * @in: image to save 
  * @filename: file to write to 
  * @...: %NULL-terminated list of optional named arguments
@@ -408,9 +408,9 @@ vips_webpsave( VipsImage *in, const char *filename, ... )
 }
 
 /**
- * vips_webpsave_buffer:
+ * vips_webpsave_buffer: (method)
  * @in: image to save 
- * @buf: return output buffer here
+ * @buf: (out) (array length=len) (element-type guint8): return output buffer here
  * @len: return output length here
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -463,7 +463,7 @@ vips_webpsave_buffer( VipsImage *in, void **buf, size_t *len, ... )
 }
 
 /**
- * vips_webpsave_mime:
+ * vips_webpsave_mime: (method)
  * @in: image to save 
  * @...: %NULL-terminated list of optional named arguments
  *


### PR DESCRIPTION
More for #741 

Apart from the `(method)` and `(out)` annotations, I've added some annotations for buffers. For example `vips_magickload_buffer`:

```
@buf: (array length=len) (element-type guint8): memory area to load
@len: (type gsize): size of memory area
```

`(element-type guint8)` has been used for other functions already, so it should be fine. g-ir-compiler ignored `@len` being set to type `size_t`, it used `gulong` instead. So I used `gsize` instead. From https://developer.gnome.org/glib/stable/glib-Basic-Types.html#gsize it states `gsize` is "An unsigned integer type of the result of the sizeof operator, corresponding to the size_t type defined in C99"