### PR TITLE
Update GObject introspection annotations for libvips/resample directory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,7 @@ headers="\
 	morphology.h \
 	type.h \
 	rect.h \
+	resample.h \
 	memory.h \
 	region.h"
 

--- a/libvips/resample/affine.c
+++ b/libvips/resample/affine.c
@@ -599,9 +599,9 @@ vips_affine_init( VipsAffine *affine )
 }
 
 /**
- * vips_affine:
+ * vips_affine: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @a: transformation matrix coefficient
  * @b: transformation matrix coefficient
  * @c: transformation matrix coefficient

--- a/libvips/resample/interpolate.c
+++ b/libvips/resample/interpolate.c
@@ -617,7 +617,7 @@ vips__interpolate_init( void )
 }
 
 /**
- * vips_interpolate_new:
+ * vips_interpolate_new: (constructor)
  * @nickname: nickname for interpolator
  *
  * Look up an interpolator from a nickname and make one. You need to free the

--- a/libvips/resample/mapim.c
+++ b/libvips/resample/mapim.c
@@ -410,9 +410,9 @@ vips_mapim_init( VipsMapim *mapim )
 }
 
 /**
- * vips_mapim:
+ * vips_mapim: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @index: index image
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -447,7 +447,7 @@ vips_mapim_init( VipsMapim *mapim )
  * Returns: 0 on success, -1 on error
  */
 int
-vips_mapim( VipsImage *in, VipsImage **out, VipsImage *index, ... ) 
+vips_mapim( VipsImage *in, VipsImage **out, VipsImage *index, ... )
 {
 	va_list ap;
 	int result;

--- a/libvips/resample/quadratic.c
+++ b/libvips/resample/quadratic.c
@@ -363,9 +363,9 @@ vips_quadratic_init( VipsQuadratic *quadratic )
 }
 
 /**
- * vips_quadratic:
+ * vips_quadratic: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @coeff: horizontal quadratic
  * @...: %NULL-terminated list of optional named arguments
  *

--- a/libvips/resample/reduce.c
+++ b/libvips/resample/reduce.c
@@ -183,9 +183,9 @@ vips_reduce_init( VipsReduce *reduce )
 }
 
 /**
- * vips_reduce:
+ * vips_reduce: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @hshrink: horizontal shrink
  * @vshrink: vertical shrink
  * @...: %NULL-terminated list of optional named arguments

--- a/libvips/resample/reduceh.cpp
+++ b/libvips/resample/reduceh.cpp
@@ -610,9 +610,9 @@ vips_reduceh_init( VipsReduceh *reduceh )
 }
 
 /**
- * vips_reduceh:
+ * vips_reduceh: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @hshrink: horizontal reduce
  * @...: %NULL-terminated list of optional named arguments
  *

--- a/libvips/resample/reducev.cpp
+++ b/libvips/resample/reducev.cpp
@@ -964,9 +964,9 @@ vips_reducev_init( VipsReducev *reducev )
 }
 
 /**
- * vips_reducev:
+ * vips_reducev: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @vshrink: horizontal reduce
  * @...: %NULL-terminated list of optional named arguments
  *

--- a/libvips/resample/resize.c
+++ b/libvips/resample/resize.c
@@ -352,9 +352,9 @@ vips_resize_init( VipsResize *resize )
 }
 
 /**
- * vips_resize:
+ * vips_resize: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @scale: scale factor
  * @...: %NULL-terminated list of optional named arguments
  *

--- a/libvips/resample/shrink.c
+++ b/libvips/resample/shrink.c
@@ -171,9 +171,9 @@ vips_shrink_init( VipsShrink *shrink )
 }
 
 /**
- * vips_shrink:
+ * vips_shrink: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @hshrink: horizontal shrink
  * @vshrink: vertical shrink
  * @...: %NULL-terminated list of optional named arguments

--- a/libvips/resample/shrinkh.c
+++ b/libvips/resample/shrinkh.c
@@ -342,9 +342,9 @@ vips_shrinkh_init( VipsShrinkh *shrink )
 }
 
 /**
- * vips_shrinkh:
+ * vips_shrinkh: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @hshrink: horizontal shrink
  * @...: %NULL-terminated list of optional named arguments
  *

--- a/libvips/resample/shrinkv.c
+++ b/libvips/resample/shrinkv.c
@@ -470,9 +470,9 @@ vips_shrinkv_init( VipsShrinkv *shrink )
 }
 
 /**
- * vips_shrinkv:
+ * vips_shrinkv: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @vshrink: vertical shrink
  * @...: %NULL-terminated list of optional named arguments
  *

--- a/libvips/resample/similarity.c
+++ b/libvips/resample/similarity.c
@@ -229,9 +229,9 @@ vips_similarity_init( VipsSimilarity *similarity )
 }
 
 /**
- * vips_similarity:
+ * vips_similarity: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Optional arguments:

--- a/libvips/resample/thumbnail.c
+++ b/libvips/resample/thumbnail.c
@@ -751,7 +751,7 @@ vips_thumbnail_file_init( VipsThumbnailFile *file )
 /**
  * vips_thumbnail:
  * @filename: file to read from
- * @out: output image
+ * @out: (out): output image
  * @width: target width in pixels
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -925,9 +925,9 @@ vips_thumbnail_buffer_init( VipsThumbnailBuffer *buffer )
 
 /**
  * vips_thumbnail_buffer:
- * @buf: memory area to load
- * @len: size of memory area
- * @out: output image
+ * @buf: (array length=len) (element-type guint8): memory area to load
+ * @len: (type gsize): size of memory area
+ * @out: (out): output image
  * @width: target width in pixels
  * @...: %NULL-terminated list of optional named arguments
  *
@@ -1040,9 +1040,9 @@ vips_thumbnail_image_init( VipsThumbnailImage *image )
 }
 
 /**
- * vips_thumbnail_image:
+ * vips_thumbnail_image: (method)
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @width: target width in pixels
  * @...: %NULL-terminated list of optional named arguments
  *


### PR DESCRIPTION
#741 

`resample.h` had to be added to `headers` in `configure.ac` for the functions to appear in the GIR. I assumed that `resample.h` was part of the public VIPS8 API.

There are also a couple of C++ files: reducev.cpp and reduceh.cpp. These look as though they have public functions, but aren't part of `instrospection_sources` in `configure.ac`. I've not made any changes to the build system for these two files.