### PR TITLE
Prefer ~10x faster sqrt instead of pow when y=0.5

### DIFF
--- a/libvips/arithmetic/math2.c
+++ b/libvips/arithmetic/math2.c
@@ -139,7 +139,9 @@ vips_math2_build( VipsObject *object )
 	\
 	/* Division by zero! Difficult to report tho' \
 	 */ \
-	(Y) = (left == 0.0 && right < 0.0) ? 0.0 : pow( left, right ); \
+	(Y) = (right == 0.5) \
+		? sqrt( left ) \
+		: (left == 0.0 && right < 0.0) ? 0.0 : pow( left, right ); \
 }
 
 #define WOP( Y, X, E ) POW( Y, E, X )


### PR DESCRIPTION
Hi John, this small change improves performance of the attention smartcrop operation by ~30% (tested with gcc 5.4 on Ubuntu 16.04).

Before:
```
20,393,996,328  /build/glibc-bfm8X4/glibc-2.23/math/../sysdeps/ieee754/dbl-64/e_pow.c:__ieee754_pow_sse2 [/lib/x86_64-linux-gnu/libm-2.23.so]
14,434,340,104  libvips/conversion/extract.c:vips_extract_band_buffer [/usr/local/lib/libvips.so.42.8.0]
 9,370,217,274  /build/glibc-bfm8X4/glibc-2.23/math/../sysdeps/ieee754/dbl-64/e_exp.c:__exp1 [/lib/x86_64-linux-gnu/libm-2.23.so]
 8,487,829,504  /build/glibc-bfm8X4/glibc-2.23/math/../sysdeps/ieee754/dbl-64/e_atan2.c:__ieee754_atan2_avx [/lib/x86_64-linux-gnu/libm-2.23.so]
 8,267,273,599  libvips/colour/LabQ2sRGB.c:vips_col_sRGB2scRGB_8 [/usr/local/lib/libvips.so.42.8.0]
 6,164,317,372  libvips/resample/affine.c:vips_affine_gen [/usr/local/lib/libvips.so.42.8.0]
 6,011,658,251  libvips/colour/XYZ2Lab.c:vips_XYZ2Lab_line [/usr/local/lib/libvips.so.42.8.0]
 5,787,091,520  libvips/colour/LabQ2sRGB.c:vips_col_scRGB2XYZ [/usr/local/lib/libvips.so.42.8.0]
 4,806,119,424  libvips/conversion/bandjoin.c:vips_bandjoin_buffer [/usr/local/lib/libvips.so.42.8.0]
 3,994,779,885  libvips/colour/sRGB2scRGB.c:vips_sRGB2scRGB_gen [/usr/local/lib/libvips.so.42.8.0]
```
After:
```
14,434,340,104  libvips/conversion/extract.c:vips_extract_band_buffer [/usr/local/lib/libvips.so.42.8.0]
 8,487,829,504  /build/glibc-bfm8X4/glibc-2.23/math/../sysdeps/ieee754/dbl-64/e_atan2.c:__ieee754_atan2_avx [/lib/x86_64-linux-gnu/libm-2.23.so]
 8,267,273,599  libvips/colour/LabQ2sRGB.c:vips_col_sRGB2scRGB_8 [/usr/local/lib/libvips.so.42.8.0]
 6,011,658,251  libvips/colour/XYZ2Lab.c:vips_XYZ2Lab_line [/usr/local/lib/libvips.so.42.8.0]
 5,787,091,520  libvips/colour/LabQ2sRGB.c:vips_col_scRGB2XYZ [/usr/local/lib/libvips.so.42.8.0]
 4,806,119,424  libvips/conversion/bandjoin.c:vips_bandjoin_buffer [/usr/local/lib/libvips.so.42.8.0]
 3,994,779,885  libvips/colour/sRGB2scRGB.c:vips_sRGB2scRGB_gen [/usr/local/lib/libvips.so.42.8.0]
```

(It looks like there might be a small gain from unrolling the inner for-loop in `vips_extract_band_buffer` when using 3 and 4 channels but that can be a different PR for another day.)