### PR TITLE
Smartcrop: ~15% speedup via a linecache

### DIFF
--- a/libvips/conversion/smartcrop.c
+++ b/libvips/conversion/smartcrop.c
@@ -248,8 +248,12 @@ vips_smartcrop_attention( VipsSmartcrop *smartcrop,
 		/* Ignore dark areas.
 		 */
 		vips_more_const1( t[2], &t[10], 5.0, NULL ) ||
-		!(t[11] = vips_image_new_from_image1( t[10], 0.0 )) ||
-		vips_ifthenelse( t[10], t[9], t[11], &t[15], NULL ) )
+		vips_linecache( t[10], &t[22],
+			"threaded", TRUE,
+			"access", VIPS_ACCESS_SEQUENTIAL,
+			NULL ) ||
+		!(t[11] = vips_image_new_from_image1( t[22], 0.0 )) ||
+		vips_ifthenelse( t[22], t[9], t[11], &t[15], NULL ) )
 		return( -1 );
 
 	/* Look for saturated areas.
@@ -257,7 +261,7 @@ vips_smartcrop_attention( VipsSmartcrop *smartcrop,
 	if( vips_colourspace( t[1], &t[12], 
 		VIPS_INTERPRETATION_LCH, NULL ) ||
 		vips_extract_band( t[12], &t[13], 1, NULL ) ||
-		vips_ifthenelse( t[10], t[13], t[11], &t[16], NULL ) )
+		vips_ifthenelse( t[22], t[13], t[11], &t[16], NULL ) )
 		return( -1 );
 
 	/* Sum, shrink, blur and find maxpos. 


### PR DESCRIPTION
Hi John, I've been doing a little profiling of the "attention" smartcrop, in this case attempting to extract a 100x10000 region from a 10000x10000 input image.

Current behaviour (gcc 5.4 `-O3`):
```
$ time vips smartcrop 10000x10000.v out.v 100 10000
real    0m18.825s
user    0m18.572s
sys     0m0.284s
```

```
36,788,404,121  ???:vips_extract_band_buffer [/usr/local/lib/libvips.so.42.8.0]
15,708,124,763  /build/glibc-bfm8X4/glibc-2.23/math/../sysdeps/ieee754/dbl-64/e_atan2.c:__ieee754_atan2_avx [/lib/x86_64-linux-gnu/libm-2.23.so]
14,953,036,753  ???:vips_col_sRGB2scRGB_8 [/usr/local/lib/libvips.so.42.8.0]
12,562,353,888  ???:vips_ifthenelse_gen [/usr/local/lib/libvips.so.42.8.0]
12,262,089,216  ???:vips_bandjoin_buffer [/usr/local/lib/libvips.so.42.8.0]
10,367,136,011  ???:vips_XYZ2Lab_line [/usr/local/lib/libvips.so.42.8.0]
 6,880,982,698  ???:vips_sRGB2scRGB_gen [/usr/local/lib/libvips.so.42.8.0]
 6,878,396,905  ???:vips_col_scRGB2XYZ [/usr/local/lib/libvips.so.42.8.0]
 5,883,590,511  ???:vips_convi_gen'2 [/usr/local/lib/libvips.so.42.8.0]
```

I noticed there's a 3-way split in the middle of the `vips_smartcrop_attention` pipeline. Adding a linecache operation just before, as this PR demonstrates, yields a ~15% performance improvement:

```
$ time vips smartcrop 10000x10000.v out.v 100 10000
real    0m15.592s
user    0m15.544s
sys     0m0.084s
```

```
28,810,327,781  ???:vips_extract_band_buffer [/usr/local/lib/libvips.so.42.8.0]
15,708,124,763  /build/glibc-bfm8X4/glibc-2.23/math/../sysdeps/ieee754/dbl-64/e_atan2.c:__ieee754_atan2_avx [/lib/x86_64-linux-gnu/libm-2.23.so]
12,562,353,888  ???:vips_ifthenelse_gen [/usr/local/lib/libvips.so.42.8.0]
12,262,089,216  ???:vips_bandjoin_buffer [/usr/local/lib/libvips.so.42.8.0]
10,367,136,011  ???:vips_XYZ2Lab_line [/usr/local/lib/libvips.so.42.8.0]
 5,883,590,511  ???:vips_convi_gen'2 [/usr/local/lib/libvips.so.42.8.0]
```

This removes a lot of over-computation, especially reducing calls to the seemingly expensive `vips_extract_band_buffer` and sRGB to scRGB pixel conversion.

The added `vips_linecache` operation is using mostly default parameters so I'm sure it can be improved further. There's probably a better place for it too, or perhaps more than one cache would help?

I had a quick look at the auto-vectorisation of `vips_extract_band_buffer` but there's not a lot that can be done to improve things here given the input pixel stride is typically 12 bytes (3-band double) and therefore not a power of 2.

The presence of `atan2` in the callgrind report suggests the XYZ to LCH conversion is quite costly also. I've yet not had a chance to look at what might be possible to improve this.