### PR TITLE
Smartcrop: ~19% speedup by getting luminance from LAB instead of LCH

### DIFF
--- a/libvips/conversion/smartcrop.c
+++ b/libvips/conversion/smartcrop.c
@@ -255,7 +255,7 @@ vips_smartcrop_attention( VipsSmartcrop *smartcrop,
 	/* Look for saturated areas.
 	 */
 	if( vips_colourspace( t[1], &t[12], 
-		VIPS_INTERPRETATION_LCH, NULL ) ||
+		VIPS_INTERPRETATION_LAB, NULL ) ||
 		vips_extract_band( t[12], &t[13], 1, NULL ) ||
 		vips_ifthenelse( t[10], t[13], t[11], &t[16], NULL ) )
 		return( -1 );


### PR DESCRIPTION
Hi John, given only the luminance band from the LCH colourspace conversion is used, I think we can instead use LAB here. If so, this provides a fairly big performance improvement (independent of #809) by avoiding the costly atan2 conversion to polar coords.

Before:
```sh
$ time vips smartcrop 10000x10000.v out.v 100 10000
real    0m18.665s
user    0m18.424s
sys     0m0.272s
```
```
36,788,404,121  ???:vips_extract_band_buffer [/usr/local/lib/libvips.so.42.8.0]
15,708,124,763  /build/glibc-bfm8X4/glibc-2.23/math/../sysdeps/ieee754/dbl-64/e_atan2.c:__ieee754_atan2_avx [/lib/x86_64-linux-gnu/libm-2.23.so]
14,953,036,753  ???:vips_col_sRGB2scRGB_8 [/usr/local/lib/libvips.so.42.8.0]
12,562,353,888  ???:vips_ifthenelse_gen [/usr/local/lib/libvips.so.42.8.0]
12,262,089,216  ???:vips_bandjoin_buffer [/usr/local/lib/libvips.so.42.8.0]
10,367,136,011  ???:vips_XYZ2Lab_line [/usr/local/lib/libvips.so.42.8.0]
```
After:
```sh
$ time vips smartcrop 10000x10000.v out.v 100 10000
real    0m15.436s
user    0m14.976s
sys     0m0.360s
```

```
36,788,404,121  ???:vips_extract_band_buffer [/usr/local/lib/libvips.so.42.8.0]
14,953,036,753  ???:vips_col_sRGB2scRGB_8 [/usr/local/lib/libvips.so.42.8.0]
12,566,217,696  ???:vips_ifthenelse_gen [/usr/local/lib/libvips.so.42.8.0]
12,262,089,216  ???:vips_bandjoin_buffer [/usr/local/lib/libvips.so.42.8.0]
10,367,136,011  ???:vips_XYZ2Lab_line [/usr/local/lib/libvips.so.42.8.0]
```