### PR TITLE
Colour: ~20% speedup for sRGB to scRGB pixel conversion

### DIFF
--- a/libvips/colour/LabQ2sRGB.c
+++ b/libvips/colour/LabQ2sRGB.c
@@ -171,7 +171,8 @@ vips_col_make_tables_RGB_8( void )
 {
 	static GOnce once = G_ONCE_INIT;
 
-	(void) g_once( &once, calcul_tables_8, NULL );
+	if( G_UNLIKELY( once.status != G_ONCE_STATUS_READY ) )
+		(void) g_once( &once, calcul_tables_8, NULL );
 }
 
 int
@@ -195,7 +196,8 @@ vips_col_make_tables_RGB_16( void )
 {
 	static GOnce once = G_ONCE_INIT;
 
-	(void) g_once( &once, calcul_tables_16, NULL );
+	if( G_UNLIKELY( once.status != G_ONCE_STATUS_READY ) )
+		(void) g_once( &once, calcul_tables_16, NULL );
 }
 
 int


### PR DESCRIPTION
Hi John, I'm increasingly seeing sRGB to scRGB colour conversion appear when profiling so thought I'd take a look at what could be done to help.

At the moment, for every pixel converted, there is a glib shared library call to `g_once`.

Here's the `-O3` timing/profile of converting 100m pixels:

```sh
$ time vips colourspace 10000x10000.v out.v scrgb
real    0m8.697s
user    0m1.672s
sys     0m1.208s
```

```
5,000,000,003  ???:vips_col_sRGB2scRGB_8 [/usr/local/lib/libvips.so.42.8.0]
2,301,250,004  ???:vips_sRGB2scRGB_gen [/usr/local/lib/libvips.so.42.8.0]
1,200,211,873  /build/glibc-bfm8X4/glibc-2.23/string/../sysdeps/x86_64/multiarch/memcpy-avx-unaligned.S:__memcpy_avx_unaligned [/lib/x86_64-linux-gnu/libc-2.23.so]
```

This PR moves the two `GOnce` instances up a scope level, which then allows their `.status` property to be checked without invoking the shared library call but whilst maintaining the existing thread-safe, lazy loading approach for LUTs.

With this change alone the CPU cycles spent in `vips_col_sRGB2scRGB_8` noticeably improves:

```
4,200,000,012  ???:vips_col_sRGB2scRGB_8 [/usr/local/lib/libvips.so.42.8.0]
2,301,250,004  ???:vips_sRGB2scRGB_gen [/usr/local/lib/libvips.so.42.8.0]
1,200,211,873  /build/glibc-bfm8X4/glibc-2.23/string/../sysdeps/x86_64/multiarch/memcpy-avx-unaligned.S:__memcpy_avx_unaligned [/lib/x86_64-linux-gnu/libc-2.23.so]
```

This code also appears to be prone to branch misprediction. Adding `__builtin_expect` branch macros for likely/unlikely paths, as used by the Linux kernel, improves things further:

```
3,900,000,015  ???:vips_col_sRGB2scRGB_8 [/usr/local/lib/libvips.so.42.8.0]
2,301,250,004  ???:vips_sRGB2scRGB_gen [/usr/local/lib/libvips.so.42.8.0]
1,200,211,873  /build/glibc-bfm8X4/glibc-2.23/string/../sysdeps/x86_64/multiarch/memcpy-avx-unaligned.S:__memcpy_avx_unaligned [/lib/x86_64-linux-gnu/libc-2.23.so]
```

I'm seeing overall improvements in the ~20-25% range.

```sh
$ time vips colourspace 10000x10000.v out.v scrgb

real    0m9.186s
user    0m1.172s
sys     0m1.044s
```

I've added macros for both "likely" and "unlikely" branches as even though only the latter is used by this PR, they may prove handy to improve similar single-use or uncommon error branches that appear in hot paths.