### PR TITLE
(Un)premultiply: ~10-15% speedup by matching clipped alpha type with IN/OUT

### DIFF
--- a/libvips/conversion/premultiply.c
+++ b/libvips/conversion/premultiply.c
@@ -78,7 +78,7 @@ G_DEFINE_TYPE( VipsPremultiply, vips_premultiply, VIPS_TYPE_CONVERSION );
 	for( x = 0; x < width; x++ ) { \
 		IN alpha = p[bands - 1]; \
 		IN clip_alpha = VIPS_CLIP( 0, alpha, max_alpha ); \
-		double nalpha = (double) clip_alpha / max_alpha; \
+		OUT nalpha = (OUT) clip_alpha / max_alpha; \
 		\
 		for( i = 0; i < bands - 1; i++ ) \
 			q[i] = p[i] * nalpha; \
@@ -98,7 +98,7 @@ G_DEFINE_TYPE( VipsPremultiply, vips_premultiply, VIPS_TYPE_CONVERSION );
 	for( x = 0; x < width; x++ ) { \
 		IN alpha = p[3]; \
 		IN clip_alpha = VIPS_CLIP( 0, alpha, max_alpha ); \
-		double nalpha = (double) clip_alpha / max_alpha; \
+		OUT nalpha = (OUT) clip_alpha / max_alpha; \
 		\
 		q[0] = p[0] * nalpha; \
 		q[1] = p[1] * nalpha; \

--- a/libvips/conversion/unpremultiply.c
+++ b/libvips/conversion/unpremultiply.c
@@ -75,8 +75,8 @@ G_DEFINE_TYPE( VipsUnpremultiply, vips_unpremultiply, VIPS_TYPE_CONVERSION );
 	\
 	for( x = 0; x < width; x++ ) { \
 		IN alpha = p[bands - 1]; \
-		int clip_alpha = VIPS_CLIP( 0, alpha, max_alpha ); \
-		double nalpha = (double) clip_alpha / max_alpha; \
+		IN clip_alpha = VIPS_CLIP( 0, alpha, max_alpha ); \
+		OUT nalpha = (OUT) clip_alpha / max_alpha; \
 		\
 		if( clip_alpha == 0 ) \
 			for( i = 0; i < bands - 1; i++ ) \
@@ -99,8 +99,8 @@ G_DEFINE_TYPE( VipsUnpremultiply, vips_unpremultiply, VIPS_TYPE_CONVERSION );
 	\
 	for( x = 0; x < width; x++ ) { \
 		IN alpha = p[3]; \
-		int clip_alpha = VIPS_CLIP( 0, alpha, max_alpha ); \
-		double nalpha = (double) clip_alpha / max_alpha; \
+		IN clip_alpha = VIPS_CLIP( 0, alpha, max_alpha ); \
+		OUT nalpha = (OUT) clip_alpha / max_alpha; \
 		\
 		if( clip_alpha == 0 ) { \
 			q[0] = 0; \


### PR DESCRIPTION
...and as a bonus improves the precision of unpremultiply for float/double input.

This change removes 3 instructions per pixel for premultiply, 5 instructions per pixel for unpremultiply. The following timings are using gcc at `-O3` with a 100m pixel input image.

Premultiply before:
```sh
$ time vips premultiply 10000x10000-4.v premultiplied.v
real    0m12.538s
user    0m0.848s
sys     0m1.348s
```
```
3,401,460,000  ???:vips_premultiply_gen [/usr/local/lib/libvips.so.42.8.0]
1,600,211,922  /build/glibc-bfm8X4/glibc-2.23/string/../sysdeps/x86_64/multiarch/memcpy-avx-unaligned.S:__memcpy_avx_unaligned [/lib/x86_64-linux-gnu/libc-2.23.so]
```

Premultiply after:
```sh
$ time vips premultiply 10000x10000-4.v premultiplied.v
real    0m12.715s
user    0m0.716s
sys     0m1.532s
```
```
3,101,450,000  ???:vips_premultiply_gen [/usr/local/lib/libvips.so.42.8.0]
1,600,211,922  /build/glibc-bfm8X4/glibc-2.23/string/../sysdeps/x86_64/multiarch/memcpy-avx-unaligned.S:__memcpy_avx_unaligned [/lib/x86_64-linux-gnu/libc-2.23.so]
```

Unpremultiply before:
```sh
$ time vips unpremultiply premultiplied.v unpremultiplied.v
real    0m12.406s
user    0m0.840s
sys     0m1.700s
```
```
2,801,460,000  ???:vips_unpremultiply_gen [/usr/local/lib/libvips.so.42.8.0]
1,600,211,888  /build/glibc-bfm8X4/glibc-2.23/string/../sysdeps/x86_64/multiarch/memcpy-avx-unaligned.S:__memcpy_avx_unaligned [/lib/x86_64-linux-gnu/libc-2.23.so]
```

Unpremultiply after
```sh
$ time vips unpremultiply premultiplied.v unpremultiplied.v
real    0m13.525s
user    0m0.764s
sys     0m1.464s
```
```
2,301,480,000  ???:vips_unpremultiply_gen [/usr/local/lib/libvips.so.42.8.0]
1,600,211,888  /build/glibc-bfm8X4/glibc-2.23/string/../sysdeps/x86_64/multiarch/memcpy-avx-unaligned.S:__memcpy_avx_unaligned [/lib/x86_64-linux-gnu/libc-2.23.so]
```