### PR TITLE
libvips v8.6.0-beta: ensure interlaced PNG input works with libpng16

### DIFF
--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -484,11 +484,6 @@ png2vips_interlace( Read *read, VipsImage *out )
 	for( y = 0; y < out->Ysize; y++ )
 		read->row_pointer[y] = VIPS_IMAGE_ADDR( out, 0, y );
 
-	/* With some libpng you get a warning unless you call this, even though
-	 * it's unnecessary.
-	 */
-	png_set_interlace_handling( read->pPng );
-
 	png_read_image( read->pPng, read->row_pointer );
 
 	png_read_end( read->pPng, NULL ); 


### PR DESCRIPTION
Hi John, commit https://github.com/jcupitt/libvips/commit/cbd9fad040c1358587d4323eded3cc7e83971ac8 added a manual call to `png_set_interlace_handling` to avoid a warning from libpng.

However, this results in the internal `num_rows` member of the opaque `png_structp` not being correctly set and so interlaced PNG input fails when using libvips 8.6.0-beta with libpng 1.6.x.

This appears to be a limitation of the current libpng so probably needs addressing upstream.

https://github.com/glennrp/libpng/blob/f23b41d7b1acc2b95be18a776c3cc4453af6598a/pngread.c#L729-L730

This PR returns things to the current "stable" behaviour of working, albeit with the existing ignorable warning.