### PR TITLE
Use ChangeLog date instead of build date

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,7 +26,7 @@ VIPS_MAJOR_VERSION=vips_major_version()
 VIPS_MINOR_VERSION=vips_minor_version()
 VIPS_MICRO_VERSION=vips_micro_version()
 VIPS_VERSION=vips_version()
-VIPS_VERSION_STRING=$VIPS_VERSION-`date`
+VIPS_VERSION_STRING=$VIPS_VERSION-`date -u -r ChangeLog`
 
 # libtool library versioning ... not user-visible (except as part of the
 # library file name) and does not correspond to major/minor/micro above


### PR DESCRIPTION
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good.

This date call works with GNU date and BSD date.

Without this patch, every build of the 'vips' openSUSE package would differ
in version.h like this:

```diff
-#define VIPS_VERSION_STRING    "8.5.9-Thu Dec 14 22:40:35 UTC 2017"
+#define VIPS_VERSION_STRING    "8.5.9-Sun Jan 20 11:56:52 UTC 2019"
```

and differ in the resulting /usr/lib64/libvips.so.42.7.8