### PR TITLE
Prevent ~15KB leak for JPEG buffer output error

### DIFF
--- a/libvips/foreign/vips2jpeg.c
+++ b/libvips/foreign/vips2jpeg.c
@@ -816,6 +816,9 @@ vips__jpeg_write_buffer( VipsImage *in,
 		Q, profile, optimize_coding, progressive, strip, no_subsample,
 		trellis_quant, overshoot_deringing, optimize_scans, 
 		quant_table ) ) {
+		term_destination( &write->cinfo );
+		VIPS_FREE( *obuf );
+		*olen = 0;
 		write_destroy( write );
 
 		return( -1 );


### PR DESCRIPTION
Hi John, this PR prevents a 15024 byte leak when an error occurs on the input side and the output is a JPEG buffer.

It's possible the `term_destination` clean-up function is not called, which means the internal `dbuf` is never "stolen" and therefore never freed.

```
==6382== 15,024 bytes in 1 blocks are possibly lost in loss record 5,935 of 5,960
==6382==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==6382==    by 0x4C2FDEF: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==6382==    by 0x9E8E565: vips_dbuf_minimum_size (dbuf.c:76)
==6382==    by 0x9E73CFA: empty_output_buffer (vips2jpeg.c:707)
==6382==    by 0xB3E035B: jpeg_start_compress (in /usr/lib/x86_64-linux-gnu/libjpeg.so.8.0.2)
==6382==    by 0x9E73FC1: write_vips (vips2jpeg.c:586)
==6382==    by 0x9E7450B: vips__jpeg_write_buffer (vips2jpeg.c:815)
==6382==    by 0x9E768EB: vips_foreign_save_jpeg_buffer_build (jpegsave.c:309)
==6382==    by 0x9E93298: vips_object_build (object.c:342)
==6382==    by 0x9E9EC37: vips_cache_operation_buildp (cache.c:860)
==6382==    by 0x9B15CEF: vips::VImage::call_option_string(char const*, char const*, vips::VOption*) (VImage.cpp:513)
==6382==    by 0x9B26B0D: vips::VImage::jpegsave_buffer(vips::VOption*) (vips-operators.cpp:1864)
```

I found this when running the sharp test suite through `valgrind` with libvips v8.6.0. The use of the new input `fail` flag in sharp v0.19.0 means this path of libvips is now tested, hence why I'd not seen this appear in the leak test results before.

Using [truncated.jpg](https://github.com/lovell/sharp/blob/master/test/fixtures/truncated.jpg)[fail=true] provides a suitable test case.