### PR TITLE
Perf: ~15% improvement in conversion to greyscale

### DIFF
--- a/libvips/colour/LabQ2sRGB.c
+++ b/libvips/colour/LabQ2sRGB.c
@@ -350,23 +350,18 @@ vips_col_scRGB2BW( int range, int *lut, float R, float G, float B,
 	int Yi;
 	float v;
 
-	/* RGB can be Nan, Inf etc. Throw those values out, they will break
-	 * our clipping.
-	 *
-	 * Don't use isnormal(), it is false for 0.0 and for subnormal
-	 * numbers. 
+	/* The usual ratio. We do this in linear space before we gamma.
 	 */
-	if( VIPS_ISNAN( R ) || VIPS_ISINF( R ) ||
-		VIPS_ISNAN( G ) || VIPS_ISINF( G ) ||
-		VIPS_ISNAN( B ) || VIPS_ISINF( B ) ) {
+	Y = 0.2 * R + 0.7 * G + 0.1 * B;
+
+	/* Y can be Nan, Inf etc. Throw those values out, they will break
+	 * our clipping.
+	 */
+	if( VIPS_ISNAN( Y ) || VIPS_ISINF( Y ) ) {
 		*g = 0; 
 
 		return( -1 );
 	}
-
-	/* The usual ratio. We do this in linear space before we gamma.
-	 */
-	Y = 0.2 * R + 0.7 * G + 0.1 * B;
 
 	/* Look up with a float index: interpolate between the nearest two
 	 * points.


### PR DESCRIPTION
Hi John, this slight reordering of the logic in `vips_col_scRGB2BW` reduces the number of costly `isinf` and `isnan` calls from 6 to 2 per pixel.

Before:
```
436,545,000  libvips/colour/LabQ2sRGB.c:vips_col_scRGB2BW [/usr/local/lib/libvips.so.42.8.1]
```
After:
```
339,535,000  libvips/colour/LabQ2sRGB.c:vips_col_scRGB2BW [/usr/local/lib/libvips.so.42.8.1]
```
I see a ~15% performance improvement as a result.

(This PR targets the `8.6` branch as the latest *magick changes on the `master` branch are not compiling cleanly on my machine and I've yet to investigate why.)