### PR TITLE
composite.cpp: silence 'missing sentinel' warnings in GCC v6+

### DIFF
--- a/libvips/conversion/composite.cpp
+++ b/libvips/conversion/composite.cpp
@@ -980,7 +980,7 @@ vips_composite_base_build( VipsObject *object )
 		if( !vips_image_hasalpha( in[i] ) ) {
 			VipsImage *x;
 
-			if( vips_addalpha( in[i], &x, NULL ) )
+			if( vips_addalpha( in[i], &x, (void *) NULL ) )
 				return( -1 );
 			g_object_unref( in[i] );
 			in[i] = x;
@@ -1032,7 +1032,7 @@ vips_composite_base_build( VipsObject *object )
 		vips_object_local_array( object, composite->n );
 	for( int i = 0; i < composite->n; i++ )
 		if( vips_colourspace( in[i], &compositing[i],
-			composite->compositing_space, NULL ) )
+			composite->compositing_space, (void *) NULL ) )
 			return( -1 );
 	in = compositing;
 


### PR DESCRIPTION
Hi John, this quick fix uses the same approach as #668.

```
composite.cpp: In function 'int vips_composite_base_build(VipsObject*)':
composite.cpp:983:39: warning: missing sentinel in function call [-Wformat=]
    if( vips_addalpha( in[i], &x, NULL ) )
                                       ^
composite.cpp:1035:39: warning: missing sentinel in function call [-Wformat=]
    composite->compositing_space, NULL ) )
                                       ^
```