### PR TITLE
Make size_t to int cast explicit to prevent compiler warning

### DIFF
--- a/cplusplus/include/vips/VImage8.h
+++ b/cplusplus/include/vips/VImage8.h
@@ -474,7 +474,7 @@ public:
 		VipsImage *image;
 
 		if( !(image = vips_image_new_from_image( this->get_image(), 
-			&pixel[0], pixel.size() )) )
+			&pixel[0], static_cast<int>( pixel.size() ) )) )
 			throw( VError() ); 
 
 		return( VImage( image ) ); 


### PR DESCRIPTION
Silences this warning seen when compiling with MSVC.

> cplusplus\include\vips\VImage8.h(477): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data
