### PR TITLE
Add "(out)" to "out" parameter in vips_addalpha()

### DIFF
--- a/libvips/conversion/bandjoin.c
+++ b/libvips/conversion/bandjoin.c
@@ -501,7 +501,7 @@ vips_bandjoin_const1( VipsImage *in, VipsImage **out, double c, ... )
 
 /* vips_addalpha:
  * @in: input image
- * @out: output image
+ * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
  * Append an alpha channel.


### PR DESCRIPTION
I don't know if this is used for function introspection (and in this case if it's related to https://github.com/jcupitt/ruby-vips/issues/168), but I saw all other functions having `(out)` specified like this.