### PR TITLE
Fix wrong value for VIPS_FOREIGN_PNG_FILTER_ALL

### DIFF
--- a/libvips/include/vips/foreign.h
+++ b/libvips/include/vips/foreign.h
@@ -518,7 +518,7 @@ typedef enum /*< flags >*/ {
 	VIPS_FOREIGN_PNG_FILTER_UP = 0x20,
 	VIPS_FOREIGN_PNG_FILTER_AVG = 0x40,
 	VIPS_FOREIGN_PNG_FILTER_PAETH = 0x80,
-	VIPS_FOREIGN_PNG_FILTER_ALL = 0xEA
+	VIPS_FOREIGN_PNG_FILTER_ALL = 0xF8
 } VipsForeignPngFilter;
 
 int vips_pngload( const char *filename, VipsImage **out, ... )


### PR DESCRIPTION
The value is derived by oring all the filter flags:

    0x08 | 0x10 | 0x20 | 0x40 | 0x80 == 0xf8

The value was also checked against PNG_ALL_FILTERS in png.h of libpng 1.6.34.