### PR TITLE
Fixed deadlock in vips_cache_drop_all if vips__cache_dump is true

### DIFF
--- a/libvips/iofuncs/cache.c
+++ b/libvips/iofuncs/cache.c
@@ -480,6 +480,16 @@ vips_cache_print_fn( void *value, void *a, void *b )
 	return( NULL );
 }
 
+void
+vips_cache_print_nolock( void )
+{
+	if( vips_cache_table ) {
+		printf( "Operation cache:\n" );
+		vips_hash_table_map( vips_cache_table,
+			vips_cache_print_fn, NULL, NULL );
+	}
+}
+
 /**
  * vips_cache_print:
  *
@@ -490,11 +500,7 @@ vips_cache_print( void )
 {
 	g_mutex_lock( vips_cache_lock );
 
-	if( vips_cache_table ) {
-		printf( "Operation cache:\n" );
-		vips_hash_table_map( vips_cache_table, 
-			vips_cache_print_fn, NULL, NULL ); 
-	}
+	vips_cache_print_nolock();
 
 	g_mutex_unlock( vips_cache_lock );
 }
@@ -662,7 +668,7 @@ vips_cache_drop_all( void )
 		VipsOperation *operation;
 
 		if( vips__cache_dump )
-			vips_cache_print();
+			vips_cache_print_nolock();
 
 		/* We can't modify the hash in the callback from
 		 * g_hash_table_foreach() and friends. Repeatedly drop the


### PR DESCRIPTION
_From the commit message:_

Both `vips_cache_drop_all` and `vips_cache_print` acquire `vips_cache_lock` on entry, but `vips_cache_drop_all` calls `vips_cache_print` internally if `vips__cache_dump` is true, leading to a deadlock situation.
This commit solves the issue using one further level of indirection and a new `vips_cache_print_nolock` function.

---

I tried adhering to the existing code style, but I'm not sure if I got this right as I only started working with libvips last week.