### PR TITLE
Reduce SVG re-renders with taller cache tiles

### DIFF
--- a/libvips/foreign/svgload.c
+++ b/libvips/foreign/svgload.c
@@ -67,6 +67,10 @@
 #include <cairo.h>
 #include <librsvg/rsvg.h>
 
+/* The maximum pixel width librsvg is able to render.
+ */
+#define RSVG_MAX_WIDTH 32767
+
 /* Old librsvg versions don't include librsvg-features.h by default.
  * Newer versions deprecate direct inclusion.
  */
@@ -359,13 +363,7 @@ vips_foreign_load_svg_load( VipsForeignLoad *load )
 
 	int tile_width;
 	int tile_height;
-	int n_lines;
 	int max_tiles;
-
-	/* Use this to pick a tile height for our strip cache.
-	 */
-	vips_get_tile_size( load->real,
-		&tile_width, &tile_height, &n_lines );
 
 	/* Read to this image, then cache to out, see below.
 	 */
@@ -383,9 +381,11 @@ vips_foreign_load_svg_load( VipsForeignLoad *load )
 	 * Don't thread the cache: we rely on this to keep calls to rsvg 
 	 * single-threaded.
 	 */
-	max_tiles = 3 * VIPS_ROUND_UP( t[0]->Xsize, 30000 ) / 30000;
+	tile_width = VIPS_MIN( t[0]->Xsize, RSVG_MAX_WIDTH );
+	tile_height = t[0]->Ysize;
+	max_tiles = VIPS_ROUND_UP( t[0]->Xsize, RSVG_MAX_WIDTH ) / RSVG_MAX_WIDTH;
 	if( vips_tilecache( t[0], &t[1],
-		"tile_width", 30000,
+		"tile_width", tile_width,
 		"tile_height", tile_height,
 		"max_tiles", max_tiles,
 		"access", VIPS_ACCESS_SEQUENTIAL,


### PR DESCRIPTION
Hi John, this was originally reported in https://github.com/lovell/sharp/issues/1222

The example [image.svg](https://raw.githubusercontent.com/nikwen/sharp-demo/master/image.svg) makes heavy use of Gaussian blur filters and takes 3.5s to render via `rsvg-convert`.

```sh
$ time rsvg-convert image.svg >output.png

real    0m3.351s
user    0m3.320s
sys     0m0.032s
```

A similar operation using the `vips` command line (latest master) takes ~10x longer.

```sh
$ time vips copy image.svg output.png

real    0m38.264s
user    0m37.548s
sys     0m0.304s
```

The SVG loader currently [defines a cache](https://github.com/jcupitt/libvips/blob/5176b4a17ec9ca5151f1b8b503b2f237f3c83b27/libvips/foreign/svgload.c#L387) to typically hold three 30000x16 tiles, but this doesn't appear to be enough to prevent multiple renders being requested from librsvg.

The proposed change in this PR alters the cache to hold vertical 32767px wide strips (see #732).

This is more in keeping with the way the PDF loader [cache is defined](https://github.com/jcupitt/libvips/blob/749f4a902a2b65a8880ee56ae5ce3fd858f28ef5/libvips/foreign/pdfload.c#L431) to avoid re-renders.

After applying this change I see:

```sh
$ time vips copy image.svg output.png

real    0m3.345s
user    0m3.316s
sys     0m0.032s
```

So comparable with, if not very slightly faster than, `rsvg-convert`.
