### PR TITLE
Fixes for being able to build libvips in Visual Studio 2017 with an external project

### DIFF
--- a/libvips/conversion/composite.cpp
+++ b/libvips/conversion/composite.cpp
@@ -47,7 +47,11 @@
 
 #include <stdio.h>
 #include <string.h>
+#if _MSC_VER
+#include <cstdlib>
+#else
 #include <stdlib.h>
+#endif
 #include <math.h>
 
 #include <vips/vips.h>

--- a/libvips/create/perlin.c
+++ b/libvips/create/perlin.c
@@ -267,7 +267,7 @@ vips_perlin_make_tables( void *client )
 	int i;
 
 	for( i = 0; i < 256; i++ ) {
-		double angle = 2 * M_PI * i / 256.0;
+		double angle = 2 * VIPS_PI * i / 256.0;
 
 		vips_perlin_cos[i] = cos( angle );
 		vips_perlin_sin[i] = sin( angle );

--- a/libvips/foreign/rawsave.c
+++ b/libvips/foreign/rawsave.c
@@ -57,7 +57,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
 #include <string.h>
 
 #include <vips/vips.h>

--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -1843,7 +1843,7 @@ rtiff_stripwise_generate( VipsRegion *or,
 
 			/* Do any repacking to generate pixels in vips layout.
 			 */
-			p = rtiff->contig_buf + 
+			p = (char*)(rtiff->contig_buf) + 
 				(hit.top - strip.top) * scanline_size;
 			q = VIPS_REGION_ADDR( or, 0, r->top + y );
 			for( z = 0; z < hit.height; z++ ) { 

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -700,7 +700,7 @@ vips_png_read_buffer( png_structp pPng, png_bytep data, png_size_t length )
 	if( read->read_pos + length > read->length )
 		png_error( pPng, "not enough data in buffer" );
 
-	memcpy( data, read->buffer + read->read_pos, length );
+	memcpy( data, (const char*)(read->buffer) + read->read_pos, length );
 	read->read_pos += length;
 }
 

--- a/libvips/include/vips/type.h
+++ b/libvips/include/vips/type.h
@@ -100,7 +100,7 @@ void *vips_area_get_data( VipsArea *area,
 #ifdef VIPS_DEBUG
 #define VIPS_ARRAY_ADDR( X, I ) \
 	(((I) >= 0 && (I) < VIPS_AREA( X )->n) ? \
-	 (VIPS_AREA( X )->data + VIPS_AREA( X )->sizeof_type * (I)) : \
+	 ((char*)(VIPS_AREA( X )->data) + VIPS_AREA( X )->sizeof_type * (I)) : \
 	 (fprintf( stderr, \
 		"VIPS_ARRAY_ADDR: index out of bounds, " \
 		"file \"%s\", line %d\n" \
@@ -109,7 +109,7 @@ void *vips_area_get_data( VipsArea *area,
 		(I), VIPS_AREA( X )->n ), NULL ))
 #else /*!VIPS_DEBUG*/
 #define VIPS_ARRAY_ADDR( X, I ) \
-	(VIPS_AREA( X )->data + VIPS_AREA( X )->sizeof_type * (I))
+	((char*)(VIPS_AREA( X )->data) + VIPS_AREA( X )->sizeof_type * (I))
 #endif /*VIPS_DEBUG*/
 
 /**

--- a/libvips/include/vips/util.h
+++ b/libvips/include/vips/util.h
@@ -79,7 +79,7 @@ extern "C" {
 #define VIPS_ISINF( V ) isinf( V )
 #define VIPS_FLOOR( V ) floor( V )
 #define VIPS_CEIL( V ) ceil( V )
-#define VIPS_RINT( R ) rint( V )
+#define VIPS_RINT( V ) rint( V )
 #define VIPS_ROUND( V ) round( V )
 #define VIPS_FABS( V ) VIPS_ABS( V )
 #define VIPS_FMAX( A, B ) VIPS_MAX( A, B )

--- a/libvips/iofuncs/generate.c
+++ b/libvips/iofuncs/generate.c
@@ -102,6 +102,9 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif /*HAVE_UNISTD_H*/
+#ifdef HAVE_IO_H
+#include <io.h>
+#endif /*HAVE_IO_H*/
 
 #include <vips/vips.h>
 #include <vips/internal.h>

--- a/libvips/iofuncs/image.c
+++ b/libvips/iofuncs/image.c
@@ -3269,7 +3269,7 @@ vips_image_wio_input( VipsImage *image )
 		 */
 		if( vips_mapfile( image ) ) 
 			return( -1 );
-		image->data = image->baseaddr + image->sizeof_header;
+		image->data = ((char*)image->baseaddr) + image->sizeof_header;
 		image->dtype = VIPS_IMAGE_MMAPIN;
 
 		break;

--- a/libvips/iofuncs/mapfile.c
+++ b/libvips/iofuncs/mapfile.c
@@ -87,6 +87,7 @@
 
 #ifdef OS_WIN32
 #include <windows.h>
+#include <io.h>
 #endif /*OS_WIN32*/
 
 void *

--- a/libvips/iofuncs/memory.c
+++ b/libvips/iofuncs/memory.c
@@ -59,7 +59,12 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+#ifdef HAVE_IO_H
+#include <io.h>
+#endif /*HAVE_IO_H*/
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>

--- a/libvips/iofuncs/util.c
+++ b/libvips/iofuncs/util.c
@@ -48,6 +48,9 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif /*HAVE_UNISTD_H*/
+#ifdef HAVE_IO_H
+#include <io.h>
+#endif /*HAVE_IO_H*/
 #include <fcntl.h>
 
 #ifdef OS_WIN32

--- a/libvips/mosaicing/im_lrmerge.c
+++ b/libvips/mosaicing/im_lrmerge.c
@@ -165,7 +165,7 @@ im__make_blend_luts( void )
 		return( -1 ); 
 
 	for( x = 0; x < BLEND_SIZE; x++ ) {
-		double a = IM_PI * x / (BLEND_SIZE - 1.0);
+		double a = VIPS_PI * x / (BLEND_SIZE - 1.0);
 
 		im__coef1[x] = (cos( a ) + 1.0) / 2.0;
 		im__coef2[x] = 1.0 - im__coef1[x];

--- a/libvipsCC/include/vips/VDisplay.h
+++ b/libvipsCC/include/vips/VDisplay.h
@@ -52,7 +52,7 @@ extern "C" {
 VIPS_NAMESPACE_START
 
 // Wrapper over im_col_display with ref counting
-class VDisplay {
+class VIPS_CC_API VDisplay {
 	struct refblock {
 		im_col_display *disp;	// im_col_display struct
 		im_col_tab_disp *luts;	// luts built from this display

--- a/libvipsCC/include/vips/VError.h
+++ b/libvipsCC/include/vips/VError.h
@@ -49,7 +49,7 @@
 VIPS_NAMESPACE_START
 
 // Error type
-class VError : public std::exception {
+class VIPS_CC_API VError : public std::exception {
 	std::string _what;
 
 public:
@@ -76,7 +76,7 @@ inline std::ostream &operator<<( std::ostream &file, const VError &err )
 	return( file );
 }
 
-void verror( std::string str = "" );
+void VIPS_CC_API verror( std::string str = "" );
 
 VIPS_NAMESPACE_END
 

--- a/libvipsCC/include/vips/VImage.h
+++ b/libvipsCC/include/vips/VImage.h
@@ -77,7 +77,7 @@ typedef int (*VCallback)( void *, void * );
  * and several other refblocks can have IMAGEs which depend upon this IMAGE
  * for their result.
  */
-class VImage {
+class VIPS_CC_API VImage {
 	/* We'd like this to be protected so that user subclasses can define
 	 * their own member wrappers. But sadly C++ doesn't work like that:
 	 * subclasses of VImage can only refer to protected members via
@@ -89,7 +89,7 @@ public:
  */
 #ifndef SWIG
 	// Count ref etc. in one of these. One for each open VIPS image.
-	struct refblock {
+	VIPS_CC_API struct refblock {
 		_VipsImage *im;			// IMAGE pointer
 		int close_on_delete;		// Set if we must im_close()
 		int nrefs;			// Number of refs to us
@@ -100,7 +100,7 @@ public:
 		virtual ~refblock();
 
 		// Add a ref - this (output image) depends upon IMAGE in
-		void addref( refblock *in );
+		VIPS_CC_API void addref( refblock *in );
 
 		// Remove a ref
 		void removeref();
@@ -420,7 +420,7 @@ public:
  * be part of the public API in case people subclass VImage and add their own
  * members.
  */
-class Vargv {
+class VIPS_CC_API Vargv {
 	// Function we are args to
 	im__function *fn;
 

--- a/libvipsCC/include/vips/VMask.h
+++ b/libvipsCC/include/vips/VMask.h
@@ -73,7 +73,7 @@ union MASKUNION {
 }; 
 
 // Private wrapper over *MASK - user does not see this
-class VPMask {
+class VIPS_CC_API VPMask {
 	friend class VMask;
 
 public:
@@ -102,7 +102,7 @@ public:
 };
 
 // Specialise for INTMASK
-class VPIMask : public VPMask {
+class VIPS_CC_API VPIMask : public VPMask {
 public:
 	VPIMask( int xsize, int ysize );
 	VPIMask( int xsize, int ysize, int scale, int offset, 
@@ -129,7 +129,7 @@ public:
 };
 
 // Specialise for DOUBLEMASK
-class VPDMask : public VPMask {
+class VIPS_CC_API VPDMask : public VPMask {
 public:
 	VPDMask( int xsize, int ysize );
 	VPDMask( int xsize, int ysize, 
@@ -167,7 +167,7 @@ inline std::ostream &operator<<( std::ostream &file,
 #endif /*!SWIG*/
 
 // Wrapper over VP?Mask with ref counting
-class VMask {
+class VIPS_CC_API VMask {
 protected:
 	struct refblock {
 		_private_detail::VPMask *pmask;	// Mask: double or int
@@ -221,11 +221,11 @@ inline std::ostream &operator<<( std::ostream &file, const VMask &msk )
 }
 
 // Need to forward ref these
-class VDMask;
-class VImage;
+class VIPS_CC_API VDMask;
+class VIPS_CC_API VImage;
 
 // Wrapper over _private_detail::VPIMask with ref counting
-class VIMask : public VMask {
+class VIPS_CC_API VIMask : public VMask {
 public:
 	VIMask( int xsize, int ysize )
 	{
@@ -314,7 +314,7 @@ public:
 };
 
 // Wrapper over _private_detail::VPDMask with ref counting
-class VDMask : public VMask {
+class VIPS_CC_API VDMask : public VMask {
 public:
 	VDMask( int xsize, int ysize )
 	{

--- a/libvipsCC/include/vips/vips
+++ b/libvipsCC/include/vips/vips
@@ -35,6 +35,18 @@
 // VImage.h uses GValue for metadata
 #include <glib-object.h>
 
+/* Define VIPS_CC_EXPORTS to build a DLL using MSVC.
+ */
+#ifdef _MSC_VER
+#  ifdef VIPS_CC_EXPORTS
+#    define VIPS_CC_API __declspec(dllexport)
+#  else
+#    define VIPS_CC_API __declspec(dllimport)
+#  endif
+#else
+#  define VIPS_CC_API
+#endif
+
 // If we have already #included the C vips headers, we have to undef a load of
 // stuff to stop vips's stupid macros messing up our enums
 #ifdef IM_VIPS_H


### PR DESCRIPTION
These are various fixes in order to build the library with my custom Visual Studio 2017 project.
My custom project is in this repository: https://github.com/angelmixu/libvips-vs2017

The explanation for the fixes are in the commit's comment.

Feel free to suggest, modify or comment them.