### PR TITLE
Ensure WebP can add metadata when compiled with libwebpmux

### DIFF
--- a/libvips/foreign/vips2webp.c
+++ b/libvips/foreign/vips2webp.c
@@ -441,7 +441,7 @@ vips_webp_add_metadata( VipsWebPWriter *writer, VipsImage *image )
 	if( is_vp8x ) {
 		/* Copy the existing VP8X body and update the flag bits.
 		 */
-		if( vips_webp_writer_append( &new, writer->mem + 20, 10 ) ) {
+		if( !vips_webp_writer_append( &new, writer->mem + 20, 10 ) ) {
 			vips_webp_writer_unset( &new );
 			return( -1 );
 		}


### PR DESCRIPTION
Hi John, when libvips is compiled with support for libwebpmux, writing WebP images with `strip=FALSE` can currently fail silently in `vips_webp_add_metadata`.

This was discovered whilst investigating https://github.com/lovell/sharp/issues/1242, which this change fixes.