### PR TITLE
Fix missing vips_addalpha() docs

### DIFF
--- a/libvips/conversion/bandjoin.c
+++ b/libvips/conversion/bandjoin.c
@@ -499,7 +499,8 @@ vips_bandjoin_const1( VipsImage *in, VipsImage **out, double c, ... )
 	return( result );
 }
 
-/* vips_addalpha: (method)
+/**
+ * vips_addalpha: (method)
  * @in: input image
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments


### PR DESCRIPTION
Docs for [`vips_addalpha()`](http://jcupitt.github.io/libvips/API/current/libvips-conversion.html#vips-addalpha) are missing from the website. I don't know if this PR fixes that, but that's the only difference I saw from the other function documentations.