### PR TITLE
Fix convolution vector path posterization

### DIFF
--- a/libvips/convolution/convi.c
+++ b/libvips/convolution/convi.c
@@ -909,7 +909,7 @@ vips_convi_intize( VipsConvi *convi, VipsImage *M )
 	 * later, so 1.0 (for example) would become 128, which is outside
 	 * signed 8 bit. 
 	 */
-	shift = ceil( log2( mx + 1 ) );
+	shift = ceil( log2( mx ) + 1 );
 
 	/* We need to sum n_points, so we have to shift right before adding a
 	 * new value to make sure we have enough range. 


### PR DESCRIPTION
This fixes posterization in the vector path for convolution caused by a typo in commit eefb2dad980c12922ad15d987be7c4b42a44d5cf.

The fix was suggested by @jcupitt.

Fixes #1001.