### PR TITLE
Run pytest verbose on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
   - make -Ctest -j$JOBS -s V=0 VERBOSE=1 check
   - LD_LIBRARY_PATH=$PWD/libvips/.libs
     DYLD_LIBRARY_PATH=$PWD/libvips/.libs
-    $PYTHON -m pytest pyvips-master
+    $PYTHON -m pytest -v pyvips-master
 
 matrix:
   allow_failures:


### PR DESCRIPTION
This should make it easier to see which tests cause problems.

This is related to #1005 and should help with troubleshooting the random segfaults on macOS.