### PR TITLE
8-Bit PNG Quantization Support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1393,7 +1393,7 @@ support webp metadata:			$with_libwebpmux
 text rendering with pangoft2: 		$with_pangoft2
 file import/export with libpng: 	$with_png
   (requires libpng-1.2.9 or later)
-support 8bpp PNG quantization:		$with_imagequant
+support 8bpp PNG quantisation:		$with_imagequant
 file import/export with libtiff:	$with_tiff
 file import/export with giflib:		$with_giflib
 file import/export with libjpeg:	$with_jpeg

--- a/configure.ac
+++ b/configure.ac
@@ -1142,6 +1142,24 @@ if test x"$with_png" != "xno"; then
   )
 fi
 
+# look for libimagequant with pkg-config (only if libpng is enabled)
+AC_ARG_WITH([imagequant],
+  AS_HELP_STRING([--without-imagequant], [build without imagequant (default: test)]))
+
+if test x"$with_imagequant" != "xno" && test x"$with_png" != "xno"; then
+  PKG_CHECK_MODULES(IMAGEQUANT, imagequant,
+    [AC_DEFINE(HAVE_IMAGEQUANT,1,[define if you have imagequant installed.])
+     with_imagequant=yes
+     PACKAGES_USED="$PACKAGES_USED imagequant"
+    ],
+    [AC_MSG_WARN([libimagequant not found; disabling 8bpp PNG support])
+     with_imagequant=no
+    ]
+  )
+else
+  with_imagequant=no
+fi
+
 # look for libjpeg with pkg-config ... fall back to our tester
 AC_ARG_WITH([jpeg], 
   AS_HELP_STRING([--without-jpeg], [build without libjpeg (default: test)]))
@@ -1260,14 +1278,14 @@ fi
 # Gather all up for VIPS_CFLAGS, VIPS_INCLUDES, VIPS_LIBS 
 # sort includes to get longer, more specific dirs first
 # helps, for example, selecting graphicsmagick over imagemagick
-VIPS_CFLAGS=`for i in $VIPS_CFLAGS $GTHREAD_CFLAGS $REQUIRED_CFLAGS $EXPAT_CFLAGS $ZLIB_CFLAGS $PANGOFT2_CFLAGS $GSF_CFLAGS $FFTW_CFLAGS $MAGICK_CFLAGS $JPEG_CFLAGS $PNG_CFLAGS $EXIF_CFLAGS $MATIO_CFLAGS $CFITSIO_CFLAGS $LIBWEBP_CFLAGS $LIBWEBPMUX_CFLAGS $GIFLIB_INCLUDES $RSVG_CFLAGS $PDFIUM_INCLUDES $POPPLER_CFLAGS $OPENEXR_CFLAGS $OPENSLIDE_CFLAGS $ORC_CFLAGS $TIFF_CFLAGS $LCMS_CFLAGS 
+VIPS_CFLAGS=`for i in $VIPS_CFLAGS $GTHREAD_CFLAGS $REQUIRED_CFLAGS $EXPAT_CFLAGS $ZLIB_CFLAGS $PANGOFT2_CFLAGS $GSF_CFLAGS $FFTW_CFLAGS $MAGICK_CFLAGS $JPEG_CFLAGS $PNG_CFLAGS $IMAGEQUANT_CFLAGS $EXIF_CFLAGS $MATIO_CFLAGS $CFITSIO_CFLAGS $LIBWEBP_CFLAGS $LIBWEBPMUX_CFLAGS $GIFLIB_INCLUDES $RSVG_CFLAGS $PDFIUM_INCLUDES $POPPLER_CFLAGS $OPENEXR_CFLAGS $OPENSLIDE_CFLAGS $ORC_CFLAGS $TIFF_CFLAGS $LCMS_CFLAGS 
 do 
 	echo $i 
 done | sort -ru`
 VIPS_CFLAGS=`echo $VIPS_CFLAGS`
 VIPS_CFLAGS="$VIPS_DEBUG_FLAGS $VIPS_CFLAGS"
 VIPS_INCLUDES="$ZLIB_INCLUDES $PNG_INCLUDES $TIFF_INCLUDES $JPEG_INCLUDES" 
-VIPS_LIBS="$ZLIB_LIBS $MAGICK_LIBS $PNG_LIBS $TIFF_LIBS $JPEG_LIBS $GTHREAD_LIBS $REQUIRED_LIBS $EXPAT_LIBS $PANGOFT2_LIBS $GSF_LIBS $FFTW_LIBS $ORC_LIBS $LCMS_LIBS $GIFLIB_LIBS $RSVG_LIBS $PDFIUM_LIBS $POPPLER_LIBS $OPENEXR_LIBS $OPENSLIDE_LIBS $CFITSIO_LIBS $LIBWEBP_LIBS $LIBWEBPMUX_LIBS $MATIO_LIBS $EXIF_LIBS -lm"
+VIPS_LIBS="$ZLIB_LIBS $MAGICK_LIBS $PNG_LIBS $IMAGEQUANT_LIBS $TIFF_LIBS $JPEG_LIBS $GTHREAD_LIBS $REQUIRED_LIBS $EXPAT_LIBS $PANGOFT2_LIBS $GSF_LIBS $FFTW_LIBS $ORC_LIBS $LCMS_LIBS $GIFLIB_LIBS $RSVG_LIBS $PDFIUM_LIBS $POPPLER_LIBS $OPENEXR_LIBS $OPENSLIDE_LIBS $CFITSIO_LIBS $LIBWEBP_LIBS $LIBWEBPMUX_LIBS $MATIO_LIBS $EXIF_LIBS -lm"
 
 AC_SUBST(VIPS_LIBDIR)
 
@@ -1375,6 +1393,7 @@ support webp metadata:			$with_libwebpmux
 text rendering with pangoft2: 		$with_pangoft2
 file import/export with libpng: 	$with_png
   (requires libpng-1.2.9 or later)
+support 8bpp PNG quantization:		$with_imagequant
 file import/export with libtiff:	$with_tiff
 file import/export with giflib:		$with_giflib
 file import/export with libjpeg:	$with_jpeg

--- a/libvips/foreign/pforeign.h
+++ b/libvips/foreign/pforeign.h
@@ -197,11 +197,11 @@ int vips__png_header_buffer( const void *buffer, size_t length, VipsImage *out )
 
 int vips__png_write( VipsImage *in, const char *filename, 
 	int compress, int interlace, const char *profile,
-	VipsForeignPngFilter filter, gboolean strip, int colors, int Q, double dither );
+	VipsForeignPngFilter filter, gboolean strip, int colours, int Q, double dither );
 int vips__png_write_buf( VipsImage *in, 
 	void **obuf, size_t *olen, int compression, int interlace, 
 	const char *profile, VipsForeignPngFilter filter, gboolean strip,
-	int colors, int Q, double dither );
+	int colours, int Q, double dither );
 
 /* Map WEBP metadata names to vips names.
  */

--- a/libvips/foreign/pforeign.h
+++ b/libvips/foreign/pforeign.h
@@ -197,10 +197,11 @@ int vips__png_header_buffer( const void *buffer, size_t length, VipsImage *out )
 
 int vips__png_write( VipsImage *in, const char *filename, 
 	int compress, int interlace, const char *profile,
-	VipsForeignPngFilter filter, gboolean strip );
+	VipsForeignPngFilter filter, gboolean strip, int colors, int Q, double dither );
 int vips__png_write_buf( VipsImage *in, 
 	void **obuf, size_t *olen, int compression, int interlace, 
-	const char *profile, VipsForeignPngFilter filter, gboolean strip );
+	const char *profile, VipsForeignPngFilter filter, gboolean strip,
+	int colors, int Q, double dither );
 
 /* Map WEBP metadata names to vips names.
  */

--- a/libvips/foreign/pforeign.h
+++ b/libvips/foreign/pforeign.h
@@ -197,11 +197,12 @@ int vips__png_header_buffer( const void *buffer, size_t length, VipsImage *out )
 
 int vips__png_write( VipsImage *in, const char *filename, 
 	int compress, int interlace, const char *profile,
-	VipsForeignPngFilter filter, gboolean strip, int colours, int Q, double dither );
+	VipsForeignPngFilter filter, gboolean strip,
+	gboolean palette, int colours, int Q, double dither );
 int vips__png_write_buf( VipsImage *in, 
 	void **obuf, size_t *olen, int compression, int interlace, 
 	const char *profile, VipsForeignPngFilter filter, gboolean strip,
-	int colours, int Q, double dither );
+	gboolean palette, int colours, int Q, double dither );
 
 /* Map WEBP metadata names to vips names.
  */

--- a/libvips/foreign/pngsave.c
+++ b/libvips/foreign/pngsave.c
@@ -60,6 +60,7 @@ typedef struct _VipsForeignSavePng {
 	gboolean interlace;
 	char *profile;
 	VipsForeignPngFilter filter;
+	gboolean palette;
 	int colours;
 	int Q;
 	double dither;
@@ -136,21 +137,28 @@ vips_foreign_save_png_class_init( VipsForeignSavePngClass *class )
 		VIPS_TYPE_FOREIGN_PNG_FILTER,
 		VIPS_FOREIGN_PNG_FILTER_ALL );
 
-	VIPS_ARG_INT( class, "colours", 13,
+	VIPS_ARG_BOOL( class, "palette", 13,
+		_( "Palette" ),
+		_( "Quantise to 8bpp palette" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignSavePng, palette ),
+		FALSE );
+
+	VIPS_ARG_INT( class, "colours", 14,
 		_( "Colours" ),
 		_( "Max number of palette colours" ),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET( VipsForeignSavePng, colours ),
 		2, 256, 256 );
 
-	VIPS_ARG_INT( class, "Q", 14,
+	VIPS_ARG_INT( class, "Q", 15,
 		_( "Quality" ),
 		_( "Quantisation quality" ),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET( VipsForeignSavePng, Q ),
 		0, 100, 100 );
 
-	VIPS_ARG_DOUBLE( class, "dither", 15,
+	VIPS_ARG_DOUBLE( class, "dither", 16,
 		_( "Dithering" ),
 		_( "Amount of dithering" ),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
@@ -164,7 +172,7 @@ vips_foreign_save_png_init( VipsForeignSavePng *png )
 {
 	png->compression = 6;
 	png->filter = VIPS_FOREIGN_PNG_FILTER_ALL;
-	png->colours = 0;
+	png->colours = 256;
 	png->Q = 100;
 	png->dither = 1.0;
 }
@@ -193,8 +201,8 @@ vips_foreign_save_png_file_build( VipsObject *object )
 
 	if( vips__png_write( save->ready, 
 		png_file->filename, png->compression, png->interlace, 
-		png->profile, png->filter, save->strip, png->colours, png->Q,
-		png->dither ) )
+		png->profile, png->filter, save->strip, png->palette,
+		png->colours, png->Q, png->dither ) )
 		return( -1 );
 
 	return( 0 );
@@ -253,7 +261,7 @@ vips_foreign_save_png_buffer_build( VipsObject *object )
 
 	if( vips__png_write_buf( save->ready, &obuf, &olen,
 		png->compression, png->interlace, png->profile, png->filter,
-		save->strip, png->colours, png->Q, png->dither ) )
+		save->strip, png->palette, png->colours, png->Q, png->dither ) )
 		return( -1 );
 
 	/* vips__png_write_buf() makes a buffer that needs g_free(), not
@@ -306,7 +314,8 @@ vips_foreign_save_png_buffer_init( VipsForeignSavePngBuffer *buffer )
  * * @interlace: interlace image
  * * @profile: ICC profile to embed
  * * @filter: #VipsForeignPngFilter row filter flag(s)
- * * @colours: enable 8bpp quantisation with max n colours
+ * * @palette: enable quantisation to 8bpp palette
+ * * @colours: max number of palette colours for quantisation
  * * @Q: quality for 8bpp quantisation (does not exceed @colours)
  * * @dither: amount of dithering for 8bpp quantization
  *
@@ -335,11 +344,11 @@ vips_foreign_save_png_buffer_init( VipsForeignSavePngBuffer *buffer )
  * alpha before saving. Images with more than one byte per band element are
  * saved as 16-bit PNG, others are saved as 8-bit PNG.
  *
- * If @colours is given, it limits the maximum number of colours in the image
- * and the source image will be quantised down to an 8-Bit one band indexed
- * image with palette based alpha transparency. Similar to JPEG the quality
- * can be controlled with the @Q parameter and the amount of Floyd-Steinberg
- * dithering is set with @dither.
+ * Set @palette to %TRUE to enable quantisation to an 8-bit per pixel palette
+ * image with alpha transparency support. If @colours is given, it limits the
+ * maximum number of palette entries. Similar to JPEG the quality can also be
+ * be changed with the @Q parameter which further reduces the palette size and
+ * @dither controls the amount of Floyd-Steinberg dithering.
  * This feature requires libvips to be compiled with libimagequant.
  *
  * See also: vips_image_new_from_file().

--- a/libvips/foreign/pngsave.c
+++ b/libvips/foreign/pngsave.c
@@ -144,11 +144,11 @@ vips_foreign_save_png_class_init( VipsForeignSavePngClass *class )
 		2, 256, 256 );
 
 	VIPS_ARG_INT( class, "Q", 14,
-		_( "Q" ),
-		_( "Q factor" ),
+		_( "Quality" ),
+		_( "Quantization quality" ),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET( VipsForeignSavePng, Q ),
-		0, 100, 75 );
+		0, 100, 100 );
 
 	VIPS_ARG_DOUBLE( class, "dither", 15,
 		_( "Dithering" ),
@@ -165,7 +165,7 @@ vips_foreign_save_png_init( VipsForeignSavePng *png )
 	png->compression = 6;
 	png->filter = VIPS_FOREIGN_PNG_FILTER_ALL;
 	png->colors = 0;
-	png->Q = 75;
+	png->Q = 100;
 	png->dither = 1.0;
 }
 

--- a/libvips/foreign/pngsave.c
+++ b/libvips/foreign/pngsave.c
@@ -60,7 +60,7 @@ typedef struct _VipsForeignSavePng {
 	gboolean interlace;
 	char *profile;
 	VipsForeignPngFilter filter;
-	int colors;
+	int colours;
 	int Q;
 	double dither;
 } VipsForeignSavePng;
@@ -136,16 +136,16 @@ vips_foreign_save_png_class_init( VipsForeignSavePngClass *class )
 		VIPS_TYPE_FOREIGN_PNG_FILTER,
 		VIPS_FOREIGN_PNG_FILTER_ALL );
 
-	VIPS_ARG_INT( class, "colors", 13,
-		_( "Colors" ),
-		_( "Number of palette entries" ),
+	VIPS_ARG_INT( class, "colours", 13,
+		_( "Colours" ),
+		_( "Max number of palette colours" ),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
-		G_STRUCT_OFFSET( VipsForeignSavePng, colors ),
+		G_STRUCT_OFFSET( VipsForeignSavePng, colours ),
 		2, 256, 256 );
 
 	VIPS_ARG_INT( class, "Q", 14,
 		_( "Quality" ),
-		_( "Quantization quality" ),
+		_( "Quantisation quality" ),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET( VipsForeignSavePng, Q ),
 		0, 100, 100 );
@@ -164,7 +164,7 @@ vips_foreign_save_png_init( VipsForeignSavePng *png )
 {
 	png->compression = 6;
 	png->filter = VIPS_FOREIGN_PNG_FILTER_ALL;
-	png->colors = 0;
+	png->colours = 0;
 	png->Q = 100;
 	png->dither = 1.0;
 }
@@ -193,7 +193,7 @@ vips_foreign_save_png_file_build( VipsObject *object )
 
 	if( vips__png_write( save->ready, 
 		png_file->filename, png->compression, png->interlace, 
-		png->profile, png->filter, save->strip, png->colors, png->Q,
+		png->profile, png->filter, save->strip, png->colours, png->Q,
 		png->dither ) )
 		return( -1 );
 
@@ -253,7 +253,7 @@ vips_foreign_save_png_buffer_build( VipsObject *object )
 
 	if( vips__png_write_buf( save->ready, &obuf, &olen,
 		png->compression, png->interlace, png->profile, png->filter,
-		save->strip, png->colors, png->Q, png->dither ) )
+		save->strip, png->colours, png->Q, png->dither ) )
 		return( -1 );
 
 	/* vips__png_write_buf() makes a buffer that needs g_free(), not
@@ -306,8 +306,8 @@ vips_foreign_save_png_buffer_init( VipsForeignSavePngBuffer *buffer )
  * * @interlace: interlace image
  * * @profile: ICC profile to embed
  * * @filter: #VipsForeignPngFilter row filter flag(s)
- * * @colors: enable 8bpp quantization with max n colors
- * * @Q: quality for 8bpp quantization (does not exceed @colors)
+ * * @colours: enable 8bpp quantisation with max n colours
+ * * @Q: quality for 8bpp quantisation (does not exceed @colours)
  * * @dither: amount of dithering for 8bpp quantization
  *
  * Write a VIPS image to a file as PNG.
@@ -335,8 +335,8 @@ vips_foreign_save_png_buffer_init( VipsForeignSavePngBuffer *buffer )
  * alpha before saving. Images with more than one byte per band element are
  * saved as 16-bit PNG, others are saved as 8-bit PNG.
  *
- * If @colors is given, it limits the maximum number of colors in the image
- * and the source image will be quantized down to an 8-Bit one band indexed
+ * If @colours is given, it limits the maximum number of colours in the image
+ * and the source image will be quantised down to an 8-Bit one band indexed
  * image with palette based alpha transparency. Similar to JPEG the quality
  * can be controlled with the @Q parameter and the amount of Floyd-Steinberg
  * dithering is set with @dither.

--- a/test/test_formats.sh
+++ b/test/test_formats.sh
@@ -197,7 +197,7 @@ fi
 if test_supported pngload; then
 	test_format $image png 0
 	test_format $image png 0 [compression=9,interlace=1]
-	test_format $image png 90 [colours=256,Q=100,dither=0,compression=9,interlace=1]
+	test_format $image png 90 [palette,colours=256,Q=100,dither=0,interlace=1]
 fi
 if test_supported jpegload; then
 	test_format $image jpg 90

--- a/test/test_formats.sh
+++ b/test/test_formats.sh
@@ -197,7 +197,7 @@ fi
 if test_supported pngload; then
 	test_format $image png 0
 	test_format $image png 0 [compression=9,interlace=1]
-	test_format $image png 90 [colors=256,Q=100,dither=0,compression=9,interlace=1]
+	test_format $image png 90 [colours=256,Q=100,dither=0,compression=9,interlace=1]
 fi
 if test_supported jpegload; then
 	test_format $image jpg 90

--- a/test/test_formats.sh
+++ b/test/test_formats.sh
@@ -196,7 +196,8 @@ if test_supported tiffload; then
 fi
 if test_supported pngload; then
 	test_format $image png 0
- 	test_format $image png 0 [compression=9,interlace=1]
+	test_format $image png 0 [compression=9,interlace=1]
+	test_format $image png 90 [colors=256,Q=100,dither=0,compression=9,interlace=1]
 fi
 if test_supported jpegload; then
 	test_format $image jpg 90


### PR DESCRIPTION
This adds support for saving 8-Bit one band palette based PNG images with palette based alpha channel (often called PNG8+Alpha).

The image is first converted to sRGBA and then quantized using [libimagequant](https://pngquant.org/lib/) controlled by the `colors`, `Q` and `dither` params.

* By default quantization is disabled and it must be enabled by specifying the `palette` flag.
* The `colours` parameter specifies the maximum number of colors (2-256).
* The `Q` parameter controls how lossy the quantization should be, similar to JPEG.
* The `dither` parameter controls how much Floyd-Steinberg dithering is used.

All of the code that deals with quantization is in the method `quantise_image` which writes back two `VipsImage` objects: a 1-band grayscale image where the pixel values correspond to the palette index and a 4-band sRGBA image of up to 256x1 px which contains the palette.

This structure should make is easy to share the quantization code with other writers or swap in a different quantization algorithm in the future.

Fixes #734.