### PR TITLE
Should use exif_tag_name_in_ifd() instead of exif_tag_get_name()

### DIFF
--- a/libvips/foreign/exif.c
+++ b/libvips/foreign/exif.c
@@ -317,8 +317,9 @@ vips_exif_attach_entry( ExifEntry *entry, VipsExifParams *params )
 	VipsBuf vips_name = VIPS_BUF_STATIC( vips_name_txt );
 	char value_txt[256];
 	VipsBuf value = VIPS_BUF_STATIC( value_txt );
+	ExifIfd ifd = exif_entry_get_ifd( entry );
 
-	if( !(tag_name = exif_tag_get_name( entry->tag )) )
+	if( !(tag_name = exif_tag_get_name_in_ifd( entry->tag, ifd )) )
 		return;
 
 	vips_buf_appendf( &vips_name, "exif-ifd%d-%s", 


### PR DESCRIPTION
vipsheader -a path/to/foo.jpg
...
exif-ifd2-ExifVersion: Exif Version 2.21 (Exif Version 2.21, Undefined, 4 components, 4 bytes)
...
exif-ifd3-InteroperabilityIndex: N (N, ASCII, 2 components, 2 bytes)
exif-ifd3-InteroperabilityVersion: 40/1 1/1 58/100 (40,  1, 0.58, Rational, 3 components, 24 bytes)

The above two tag name are incorrect, should be:

exif-ifd3-GPSLatitudeRef: N (N, ASCII, 2 components, 2 bytes)
exif-ifd3-GPSLatitude: 40/1 1/1 58/100 (40,  1, 0.58, Rational, 3 components, 24 bytes)

Signed-off-by: Water Liu <water@yunify.com>