### PR TITLE
Fix 72 byte leak when ICC profile is compatible

### DIFF
--- a/libvips/colour/icc_transform.c
+++ b/libvips/colour/icc_transform.c
@@ -1277,6 +1277,8 @@ vips_icc_is_compatible_profile( VipsImage *image,
 		return( FALSE );
 	}
 
+	VIPS_FREEF( cmsCloseProfile, profile );
+
 	return( TRUE );
 }
 


### PR DESCRIPTION
Hi John, this PR fixes a small memory leak on the "happy path" in the `vips_icc_is_compatible_profile` function added recently in commit https://github.com/jcupitt/libvips/commit/e686614f2ce4a130ecb8f264d100410ac55a7507

```
==26991== 72 bytes in 3 blocks are indirectly lost in loss record 4,012 of 5,782
==26991==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==26991==    by 0xB492177: ??? (in /usr/lib/x86_64-linux-gnu/liblcms2.so.2.0.8)
==26991==    by 0xB499CD4: cmsOpenIOhandlerFromMem (in /usr/lib/x86_64-linux-gnu/liblcms2.so.2.0.8)
==26991==    by 0xB49B544: cmsOpenProfileFromMemTHR (in /usr/lib/x86_64-linux-gnu/liblcms2.so.2.0.8)
==26991==    by 0x9EB1B90: vips_icc_is_compatible_profile (icc_transform.c:1261)
==26991==    by 0x9F34258: vips__foreign_convert_saveable (foreign.c:1526)
==26991==    by 0x9F34507: vips_foreign_save_build (foreign.c:1545)
==26991==    by 0x9F3DD27: vips_foreign_save_jpeg_buffer_build (jpegsave.c:305)
==26991==    by 0x9F59DA8: vips_object_build (object.c:367)
==26991==    by 0x9F65767: vips_cache_operation_buildp (cache.c:866)
==26991==    by 0x9BE5E4F: vips::VImage::call_option_string(char const*, char const*, vips::VOption*) (VImage.cpp:513)
==26991==    by 0x9BF8A75: vips::VImage::jpegsave_buffer(vips::VOption*) const (vips-operators.cpp:1887)
```