### PR TITLE
Silence 'missing sentinel' warnings in GCC v6+

### DIFF
--- a/libvips/conversion/composite.cpp
+++ b/libvips/conversion/composite.cpp
@@ -1193,7 +1193,7 @@ vips_composite_base_build( VipsObject *object )
 			if( vips_embed( in[i], &position[i], 
 				composite->x_offset[i - 1], 
 				composite->y_offset[i - 1], 
-				width, height, NULL ) )
+				width, height, (void *) NULL ) )
 				return( -1 );
 
 		in = position;


### PR DESCRIPTION
Another small C++ compiler warning a la https://github.com/jcupitt/libvips/pull/864
```
composite.cpp: In function 'int vips_composite_base_build(VipsObject*)':
composite.cpp:1196:25: warning: missing sentinel in function call [-Wformat=]
     width, height, NULL ) )
                         ^
```